### PR TITLE
Fix/view iter

### DIFF
--- a/pkg/cap/cluster/view.go
+++ b/pkg/cap/cluster/view.go
@@ -99,7 +99,6 @@ type View api.View
 
 func (v View) Iter(ctx context.Context) *RecordStream {
 	rs := newRecordStream(ctx, api.View(v))
-	rs.Next()
 	return rs
 }
 

--- a/pkg/cap/cluster/view_test.go
+++ b/pkg/cap/cluster/view_test.go
@@ -78,6 +78,7 @@ func TestIter(t *testing.T) {
 		c := cluster.ViewServer{RoutingTable: rt}.NewClient(nil)
 
 		it := c.Iter(ctx)
+		it.Next()
 
 		require.NotNil(t, it.Record(), "should not be exhausted")
 		require.NoError(t, it.Err, "should succeed")


### PR DESCRIPTION
Fixed view capability iterator semantics, because in PR #22 the semantics were changed by accident. Now, in order to get the first record from the iterator you have to call `Next()` first. That is to say, the correct way to iterate over all the records is:

```go
for it.Next() {
	it.Record()
}
```



 