### PR TITLE
Implement generic bounded types.

### DIFF
--- a/pkg/internal/bounded/bounded.go
+++ b/pkg/internal/bounded/bounded.go
@@ -1,0 +1,33 @@
+// Package bounded implements generic bounded types for validation.
+package bounded
+
+// Type is a bounded type.  If err == nil, then T
+// is valid.
+type Type[T any] struct {
+	t   T
+	err error
+}
+
+func (t Type[T]) Maybe() (T, error) {
+	return t.t, t.err
+}
+
+type Validator[T any] func(t T) Type[T]
+
+// Bind returns a new instance of the bounded type that
+// has been validated by f.
+func (t Type[T]) Bind(f Validator[T]) Type[T] {
+	if t.err == nil {
+		return f(t.t)
+	}
+
+	return t
+}
+
+func Failure[T any](err error) Type[T] {
+	return Type[T]{err: err}
+}
+
+func Value[T any](t T) Type[T] {
+	return Type[T]{t: t}
+}


### PR DESCRIPTION
This is another precursor to STM-based anchors, which I have split into its own PR.

This implements generic "bounded types", which are types whose possible range of values is restricted to some domain.  To define a bounded type, it is sufficient to have a union type that either contains valid data, or an error.

This is used extensively in the `feature/stm-anchor` PR as a means of sanitizing anchor paths, and I think it is a very useful pattern in general, especially as we begin to consume more data from remote sources.  If you can think of any other places in the codebase that have complex validation logic, it may be worthwhile to refactor with a bounded type.