### PR TITLE
Updated CASM + removed duplicated args

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/prometheus/procfs v0.7.3 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/urfave/cli/v2 v2.5.1
-	github.com/wetware/casm v0.0.0-20220512172652-17b91add6bac
+	github.com/wetware/casm v0.0.0-20220526201835-0f6ca66923d5
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/fx v1.17.1
 	go.uber.org/zap v1.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1158,6 +1158,8 @@ github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/wetware/casm v0.0.0-20220512172652-17b91add6bac h1:rJWzpDzccchJUCnRRP3RQGHrHGHD71Ty77zMldY64Ww=
 github.com/wetware/casm v0.0.0-20220512172652-17b91add6bac/go.mod h1:/hPIOdeX+Pnfn6PwHXvT3DTxMovLBY/4+diXleCY9/s=
+github.com/wetware/casm v0.0.0-20220526201835-0f6ca66923d5 h1:yRT6iHjOedGAtIEFwSdR/kcrGIfGMf+rzEMwMKg1cqo=
+github.com/wetware/casm v0.0.0-20220526201835-0f6ca66923d5/go.mod h1:/hPIOdeX+Pnfn6PwHXvT3DTxMovLBY/4+diXleCY9/s=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/go-logging v0.0.0-20170515211332-0457bb6b88fc/go.mod h1:bopw91TMyo8J3tvftk8xmU2kPmlrt4nScJQZU2hE5EM=

--- a/internal/cmd/client/discover.go
+++ b/internal/cmd/client/discover.go
@@ -19,19 +19,6 @@ func Discover() *cli.Command {
 		Name:  "discover",
 		Usage: "discover a wetware node and print its multiaddress",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
-				Name:    "discover",
-				Aliases: []string{"d"},
-				Usage:   "bootstrap discovery `ADDR`",
-				Value:   "/ip4/228.8.8.8/udp/8822/multicast/lo0",
-				EnvVars: []string{"WW_DISCOVER"},
-			},
-			&cli.StringFlag{
-				Name:    "ns",
-				Usage:   "cluster namespace",
-				Value:   "ww",
-				EnvVars: []string{"WW_NS"},
-			},
 			&cli.DurationFlag{
 				Name:    "timeout",
 				Aliases: []string{"t"},


### PR DESCRIPTION
- CASM uses master tip, which fixes CIDR /32 iterator
- `ww client discover` command removes duplicates for the `discover` and `ns` arguments