### PR TITLE
Upgrade to capnp v3.0.0-alpha.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wetware/ww
 go 1.18
 
 require (
-	capnproto.org/go/capnp/v3 v3.0.0-alpha.3
+	capnproto.org/go/capnp/v3 v3.0.0-alpha.4
 	github.com/btcsuite/btcd v0.22.1 // indirect
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/google/uuid v1.3.0
@@ -43,7 +43,7 @@ require (
 	github.com/lthibault/util v0.0.12
 	github.com/stretchr/testify v1.7.1
 	github.com/thejerf/suture/v4 v4.0.2
-	golang.org/x/sync v0.0.0-20220513210516-0976fa681c29
+	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 capnproto.org/go/capnp/v3 v3.0.0-alpha.3 h1:F2d51g9WVp5TzoWIUttjrkNa8u5WQmxCIk/W6YXUoDY=
 capnproto.org/go/capnp/v3 v3.0.0-alpha.3/go.mod h1:Dynqh9/LE2Wy7jYd2wIoYgqFwh3hZHCmG7j6/uCWX6c=
+capnproto.org/go/capnp/v3 v3.0.0-alpha.4 h1:bTT/0vW+8ffJ4LTWvEzrE4g56hoVIBl++E8iFQ8O6e8=
+capnproto.org/go/capnp/v3 v3.0.0-alpha.4/go.mod h1:Dynqh9/LE2Wy7jYd2wIoYgqFwh3hZHCmG7j6/uCWX6c=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -1374,6 +1376,8 @@ golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29 h1:w8s32wxx3sY+OjLlv9qltkLU5yvJzxjjgiHWLjdIcw4=
 golang.org/x/sync v0.0.0-20220513210516-0976fa681c29/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f h1:Ax0t5p6N38Ga0dThY21weqDEyz2oklo4IvDkpigvkD8=
+golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180810173357-98c5dad5d1a0/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/internal/api/anchor/anchor.capnp.go
+++ b/internal/api/anchor/anchor.capnp.go
@@ -66,7 +66,7 @@ func (s Value) SetNil() {
 
 }
 
-func (s Value) Capability() *capnp.Client {
+func (s Value) Capability() capnp.Client {
 	if s.Struct.Uint16(0) != 1 {
 		panic("Which() != capability")
 	}
@@ -81,7 +81,7 @@ func (s Value) HasCapability() bool {
 	return s.Struct.HasPtr(0)
 }
 
-func (s Value) SetCapability(c *capnp.Client) error {
+func (s Value) SetCapability(c capnp.Client) error {
 	s.Struct.SetUint16(0, 1)
 	if !c.IsValid() {
 		return s.Struct.SetPtr(0, capnp.Ptr{})
@@ -140,7 +140,7 @@ func (p Value_Future) Chan() channel.PeekableChan {
 	return channel.PeekableChan{Client: p.Future.Field(0, nil).Client()}
 }
 
-type Loader struct{ Client *capnp.Client }
+type Loader struct{ Client capnp.Client }
 
 // Loader_TypeID is the unique identifier for the type Loader.
 const Loader_TypeID = 0x8f85860d3c5e499a
@@ -226,6 +226,15 @@ func (c Loader_load) Args() Loader_load_Params {
 func (c Loader_load) AllocResults() (Loader_load_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Loader_load_Results{Struct: r}, err
+}
+
+// Loader_List is a list of Loader.
+type Loader_List = capnp.CapList[Loader]
+
+// NewLoader creates a new list of Loader.
+func NewLoader_List(s *capnp.Segment, sz int32) (Loader_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Loader](l), err
 }
 
 type Loader_load_Params struct{ capnp.Struct }
@@ -340,7 +349,7 @@ func (p Loader_load_Results_Future) Value() Value_Future {
 	return Value_Future{Future: p.Future.Field(0, nil)}
 }
 
-type Storer struct{ Client *capnp.Client }
+type Storer struct{ Client capnp.Client }
 
 // Storer_TypeID is the unique identifier for the type Storer.
 const Storer_TypeID = 0xd03a10b4ad79653b
@@ -426,6 +435,15 @@ func (c Storer_store) Args() Storer_store_Params {
 func (c Storer_store) AllocResults() (Storer_store_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 0})
 	return Storer_store_Results{Struct: r}, err
+}
+
+// Storer_List is a list of Storer.
+type Storer_List = capnp.CapList[Storer]
+
+// NewStorer creates a new list of Storer.
+func NewStorer_List(s *capnp.Segment, sz int32) (Storer_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Storer](l), err
 }
 
 type Storer_store_Params struct{ capnp.Struct }
@@ -540,7 +558,7 @@ func (p Storer_store_Results_Future) Struct() (Storer_store_Results, error) {
 	return Storer_store_Results{s}, err
 }
 
-type Register struct{ Client *capnp.Client }
+type Register struct{ Client capnp.Client }
 
 // Register_TypeID is the unique identifier for the type Register.
 const Register_TypeID = 0xdbbdb0fd1b231b9a
@@ -641,7 +659,16 @@ func Register_Methods(methods []server.Method, s Register_Server) []server.Metho
 	return methods
 }
 
-type Anchor struct{ Client *capnp.Client }
+// Register_List is a list of Register.
+type Register_List = capnp.CapList[Register]
+
+// NewRegister creates a new list of Register.
+func NewRegister_List(s *capnp.Segment, sz int32) (Register_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Register](l), err
+}
+
+type Anchor struct{ Client capnp.Client }
 
 // Anchor_TypeID is the unique identifier for the type Anchor.
 const Anchor_TypeID = 0xe41237e4098ed922
@@ -774,6 +801,15 @@ func (c Anchor_walk) Args() Anchor_walk_Params {
 func (c Anchor_walk) AllocResults() (Anchor_walk_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Anchor_walk_Results{Struct: r}, err
+}
+
+// Anchor_List is a list of Anchor.
+type Anchor_List = capnp.CapList[Anchor]
+
+// NewAnchor creates a new list of Anchor.
+func NewAnchor_List(s *capnp.Segment, sz int32) (Anchor_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Anchor](l), err
 }
 
 type Anchor_Child struct{ capnp.Struct }

--- a/internal/api/channel/channel.capnp.go
+++ b/internal/api/channel/channel.capnp.go
@@ -11,7 +11,7 @@ import (
 	context "context"
 )
 
-type Closer struct{ Client *capnp.Client }
+type Closer struct{ Client capnp.Client }
 
 // Closer_TypeID is the unique identifier for the type Closer.
 const Closer_TypeID = 0xfad0e4b80d3779c3
@@ -99,6 +99,15 @@ func (c Closer_close) AllocResults() (Closer_close_Results, error) {
 	return Closer_close_Results{Struct: r}, err
 }
 
+// Closer_List is a list of Closer.
+type Closer_List = capnp.CapList[Closer]
+
+// NewCloser creates a new list of Closer.
+func NewCloser_List(s *capnp.Segment, sz int32) (Closer_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Closer](l), err
+}
+
 type Closer_close_Params struct{ capnp.Struct }
 
 // Closer_close_Params_TypeID is the unique identifier for the type Closer_close_Params.
@@ -183,7 +192,7 @@ func (p Closer_close_Results_Future) Struct() (Closer_close_Results, error) {
 	return Closer_close_Results{s}, err
 }
 
-type Sender struct{ Client *capnp.Client }
+type Sender struct{ Client capnp.Client }
 
 // Sender_TypeID is the unique identifier for the type Sender.
 const Sender_TypeID = 0xe8bbed1438ea16ee
@@ -271,6 +280,15 @@ func (c Sender_send) AllocResults() (stream.StreamResult, error) {
 	return stream.StreamResult{Struct: r}, err
 }
 
+// Sender_List is a list of Sender.
+type Sender_List = capnp.CapList[Sender]
+
+// NewSender creates a new list of Sender.
+func NewSender_List(s *capnp.Segment, sz int32) (Sender_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Sender](l), err
+}
+
 type Sender_send_Params struct{ capnp.Struct }
 
 // Sender_send_Params_TypeID is the unique identifier for the type Sender_send_Params.
@@ -329,7 +347,7 @@ func (p Sender_send_Params_Future) Value() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
 
-type Peeker struct{ Client *capnp.Client }
+type Peeker struct{ Client capnp.Client }
 
 // Peeker_TypeID is the unique identifier for the type Peeker.
 const Peeker_TypeID = 0xe95c7f9f41bf520a
@@ -415,6 +433,15 @@ func (c Peeker_peek) Args() Peeker_peek_Params {
 func (c Peeker_peek) AllocResults() (Peeker_peek_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Peeker_peek_Results{Struct: r}, err
+}
+
+// Peeker_List is a list of Peeker.
+type Peeker_List = capnp.CapList[Peeker]
+
+// NewPeeker creates a new list of Peeker.
+func NewPeeker_List(s *capnp.Segment, sz int32) (Peeker_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Peeker](l), err
 }
 
 type Peeker_peek_Params struct{ capnp.Struct }
@@ -517,7 +544,7 @@ func (p Peeker_peek_Results_Future) Value() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
 
-type Recver struct{ Client *capnp.Client }
+type Recver struct{ Client capnp.Client }
 
 // Recver_TypeID is the unique identifier for the type Recver.
 const Recver_TypeID = 0xdf05a90d671c0c07
@@ -603,6 +630,15 @@ func (c Recver_recv) Args() Recver_recv_Params {
 func (c Recver_recv) AllocResults() (Recver_recv_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Recver_recv_Results{Struct: r}, err
+}
+
+// Recver_List is a list of Recver.
+type Recver_List = capnp.CapList[Recver]
+
+// NewRecver creates a new list of Recver.
+func NewRecver_List(s *capnp.Segment, sz int32) (Recver_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Recver](l), err
 }
 
 type Recver_recv_Params struct{ capnp.Struct }
@@ -705,7 +741,7 @@ func (p Recver_recv_Results_Future) Value() *capnp.Future {
 	return p.Future.Field(0, nil)
 }
 
-type SendCloser struct{ Client *capnp.Client }
+type SendCloser struct{ Client capnp.Client }
 
 // SendCloser_TypeID is the unique identifier for the type SendCloser.
 const SendCloser_TypeID = 0xe9a7d19a7d14e94e
@@ -806,7 +842,16 @@ func SendCloser_Methods(methods []server.Method, s SendCloser_Server) []server.M
 	return methods
 }
 
-type PeekRecver struct{ Client *capnp.Client }
+// SendCloser_List is a list of SendCloser.
+type SendCloser_List = capnp.CapList[SendCloser]
+
+// NewSendCloser creates a new list of SendCloser.
+func NewSendCloser_List(s *capnp.Segment, sz int32) (SendCloser_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[SendCloser](l), err
+}
+
+type PeekRecver struct{ Client capnp.Client }
 
 // PeekRecver_TypeID is the unique identifier for the type PeekRecver.
 const PeekRecver_TypeID = 0x9a4abff8ccb5093c
@@ -907,7 +952,16 @@ func PeekRecver_Methods(methods []server.Method, s PeekRecver_Server) []server.M
 	return methods
 }
 
-type Chan struct{ Client *capnp.Client }
+// PeekRecver_List is a list of PeekRecver.
+type PeekRecver_List = capnp.CapList[PeekRecver]
+
+// NewPeekRecver creates a new list of PeekRecver.
+func NewPeekRecver_List(s *capnp.Segment, sz int32) (PeekRecver_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[PeekRecver](l), err
+}
+
+type Chan struct{ Client capnp.Client }
 
 // Chan_TypeID is the unique identifier for the type Chan.
 const Chan_TypeID = 0x95c89fe7d966f751
@@ -1038,7 +1092,16 @@ func Chan_Methods(methods []server.Method, s Chan_Server) []server.Method {
 	return methods
 }
 
-type PeekableChan struct{ Client *capnp.Client }
+// Chan_List is a list of Chan.
+type Chan_List = capnp.CapList[Chan]
+
+// NewChan creates a new list of Chan.
+func NewChan_List(s *capnp.Segment, sz int32) (Chan_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Chan](l), err
+}
+
+type PeekableChan struct{ Client capnp.Client }
 
 // PeekableChan_TypeID is the unique identifier for the type PeekableChan.
 const PeekableChan_TypeID = 0xb527cbca9bbd8178
@@ -1197,6 +1260,15 @@ func PeekableChan_Methods(methods []server.Method, s PeekableChan_Server) []serv
 	})
 
 	return methods
+}
+
+// PeekableChan_List is a list of PeekableChan.
+type PeekableChan_List = capnp.CapList[PeekableChan]
+
+// NewPeekableChan creates a new list of PeekableChan.
+func NewPeekableChan_List(s *capnp.Segment, sz int32) (PeekableChan_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[PeekableChan](l), err
 }
 
 const schema_872a451f9aa74ebf = "x\xda\x8cU]h#U\x14>'s\xefL\x1b6" +

--- a/internal/api/cluster/cluster.capnp.go
+++ b/internal/api/cluster/cluster.capnp.go
@@ -12,7 +12,7 @@ import (
 	channel "github.com/wetware/ww/internal/api/channel"
 )
 
-type View struct{ Client *capnp.Client }
+type View struct{ Client capnp.Client }
 
 // View_TypeID is the unique identifier for the type View.
 const View_TypeID = 0x8a1df0335afc249a
@@ -145,6 +145,15 @@ func (c View_lookup) Args() View_lookup_Params {
 func (c View_lookup) AllocResults() (View_lookup_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 8, PointerCount: 1})
 	return View_lookup_Results{Struct: r}, err
+}
+
+// View_List is a list of View.
+type View_List = capnp.CapList[View]
+
+// NewView creates a new list of View.
+func NewView_List(s *capnp.Segment, sz int32) (View_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[View](l), err
 }
 
 type View_Record struct{ capnp.Struct }
@@ -467,7 +476,7 @@ func (p View_lookup_Results_Future) Record() View_Record_Future {
 	return View_Record_Future{Future: p.Future.Field(0, nil)}
 }
 
-type Host struct{ Client *capnp.Client }
+type Host struct{ Client capnp.Client }
 
 // Host_TypeID is the unique identifier for the type Host.
 const Host_TypeID = 0x957cbefc645fd307
@@ -613,6 +622,15 @@ func (c Host_view) Args() Host_view_Params {
 func (c Host_view) AllocResults() (Host_view_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Host_view_Results{Struct: r}, err
+}
+
+// Host_List is a list of Host.
+type Host_List = capnp.CapList[Host]
+
+// NewHost creates a new list of Host.
+func NewHost_List(s *capnp.Segment, sz int32) (Host_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Host](l), err
 }
 
 type Host_view_Params struct{ capnp.Struct }

--- a/internal/api/iostream/iostream.capnp.go
+++ b/internal/api/iostream/iostream.capnp.go
@@ -12,7 +12,7 @@ import (
 	channel "github.com/wetware/ww/internal/api/channel"
 )
 
-type Stream struct{ Client *capnp.Client }
+type Stream struct{ Client capnp.Client }
 
 // Stream_TypeID is the unique identifier for the type Stream.
 const Stream_TypeID = 0x800fee1ed6b441e2
@@ -113,7 +113,16 @@ func Stream_Methods(methods []server.Method, s Stream_Server) []server.Method {
 	return methods
 }
 
-type Provider struct{ Client *capnp.Client }
+// Stream_List is a list of Stream.
+type Stream_List = capnp.CapList[Stream]
+
+// NewStream creates a new list of Stream.
+func NewStream_List(s *capnp.Segment, sz int32) (Stream_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Stream](l), err
+}
+
+type Provider struct{ Client capnp.Client }
 
 // Provider_TypeID is the unique identifier for the type Provider.
 const Provider_TypeID = 0xec225e7f00ef3b55
@@ -199,6 +208,15 @@ func (c Provider_provide) Args() Provider_provide_Params {
 func (c Provider_provide) AllocResults() (Provider_provide_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 0})
 	return Provider_provide_Results{Struct: r}, err
+}
+
+// Provider_List is a list of Provider.
+type Provider_List = capnp.CapList[Provider]
+
+// NewProvider creates a new list of Provider.
+func NewProvider_List(s *capnp.Segment, sz int32) (Provider_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Provider](l), err
 }
 
 type Provider_provide_Params struct{ capnp.Struct }

--- a/internal/api/proc/proc.capnp.go
+++ b/internal/api/proc/proc.capnp.go
@@ -11,7 +11,7 @@ import (
 	iostream "github.com/wetware/ww/internal/api/iostream"
 )
 
-type Executor struct{ Client *capnp.Client }
+type Executor struct{ Client capnp.Client }
 
 // Executor_TypeID is the unique identifier for the type Executor.
 const Executor_TypeID = 0xe8bb307fa2f406fb
@@ -97,6 +97,15 @@ func (c Executor_exec) Args() Executor_exec_Params {
 func (c Executor_exec) AllocResults() (Executor_exec_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Executor_exec_Results{Struct: r}, err
+}
+
+// Executor_List is a list of Executor.
+type Executor_List = capnp.CapList[Executor]
+
+// NewExecutor creates a new list of Executor.
+func NewExecutor_List(s *capnp.Segment, sz int32) (Executor_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Executor](l), err
 }
 
 type Executor_exec_Params struct{ capnp.Struct }
@@ -221,7 +230,7 @@ func (p Executor_exec_Results_Future) Proc() Waiter {
 	return Waiter{Client: p.Future.Field(0, nil).Client()}
 }
 
-type Waiter struct{ Client *capnp.Client }
+type Waiter struct{ Client capnp.Client }
 
 // Waiter_TypeID is the unique identifier for the type Waiter.
 const Waiter_TypeID = 0xc66c9bda04b0f29e
@@ -309,6 +318,15 @@ func (c Waiter_wait) AllocResults() (Waiter_wait_Results, error) {
 	return Waiter_wait_Results{Struct: r}, err
 }
 
+// Waiter_List is a list of Waiter.
+type Waiter_List = capnp.CapList[Waiter]
+
+// NewWaiter creates a new list of Waiter.
+func NewWaiter_List(s *capnp.Segment, sz int32) (Waiter_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Waiter](l), err
+}
+
 type Waiter_wait_Params struct{ capnp.Struct }
 
 // Waiter_wait_Params_TypeID is the unique identifier for the type Waiter_wait_Params.
@@ -393,7 +411,7 @@ func (p Waiter_wait_Results_Future) Struct() (Waiter_wait_Results, error) {
 	return Waiter_wait_Results{s}, err
 }
 
-type Unix struct{ Client *capnp.Client }
+type Unix struct{ Client capnp.Client }
 
 // Unix_TypeID is the unique identifier for the type Unix.
 const Unix_TypeID = 0x85f7549a53596cef
@@ -462,6 +480,15 @@ func Unix_Methods(methods []server.Method, s Unix_Server) []server.Method {
 	})
 
 	return methods
+}
+
+// Unix_List is a list of Unix.
+type Unix_List = capnp.CapList[Unix]
+
+// NewUnix creates a new list of Unix.
+func NewUnix_List(s *capnp.Segment, sz int32) (Unix_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Unix](l), err
 }
 
 type Unix_Command struct{ capnp.Struct }
@@ -656,7 +683,7 @@ func (p Unix_Command_Future) Stderr() iostream.Stream {
 	return iostream.Stream{Client: p.Future.Field(6, nil).Client()}
 }
 
-type Unix_Proc struct{ Client *capnp.Client }
+type Unix_Proc struct{ Client capnp.Client }
 
 // Unix_Proc_TypeID is the unique identifier for the type Unix_Proc.
 const Unix_Proc_TypeID = 0xa56f29d54a3673af
@@ -772,6 +799,15 @@ func (c Unix_Proc_signal) Args() Unix_Proc_signal_Params {
 func (c Unix_Proc_signal) AllocResults() (Unix_Proc_signal_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 0})
 	return Unix_Proc_signal_Results{Struct: r}, err
+}
+
+// Unix_Proc_List is a list of Unix_Proc.
+type Unix_Proc_List = capnp.CapList[Unix_Proc]
+
+// NewUnix_Proc creates a new list of Unix_Proc.
+func NewUnix_Proc_List(s *capnp.Segment, sz int32) (Unix_Proc_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Unix_Proc](l), err
 }
 
 type Unix_Proc_Signal uint16

--- a/internal/api/pubsub/pubsub.capnp.go
+++ b/internal/api/pubsub/pubsub.capnp.go
@@ -11,7 +11,7 @@ import (
 	channel "github.com/wetware/ww/internal/api/channel"
 )
 
-type Topic struct{ Client *capnp.Client }
+type Topic struct{ Client capnp.Client }
 
 // Topic_TypeID is the unique identifier for the type Topic.
 const Topic_TypeID = 0x986ea9282f106bb0
@@ -191,6 +191,15 @@ func (c Topic_name) Args() Topic_name_Params {
 func (c Topic_name) AllocResults() (Topic_name_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return Topic_name_Results{Struct: r}, err
+}
+
+// Topic_List is a list of Topic.
+type Topic_List = capnp.CapList[Topic]
+
+// NewTopic creates a new list of Topic.
+func NewTopic_List(s *capnp.Segment, sz int32) (Topic_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[Topic](l), err
 }
 
 type Topic_publish_Params struct{ capnp.Struct }
@@ -498,7 +507,7 @@ func (p Topic_name_Results_Future) Struct() (Topic_name_Results, error) {
 	return Topic_name_Results{s}, err
 }
 
-type PubSub struct{ Client *capnp.Client }
+type PubSub struct{ Client capnp.Client }
 
 // PubSub_TypeID is the unique identifier for the type PubSub.
 const PubSub_TypeID = 0xf1cc149f1c06e50e
@@ -584,6 +593,15 @@ func (c PubSub_join) Args() PubSub_join_Params {
 func (c PubSub_join) AllocResults() (PubSub_join_Results, error) {
 	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
 	return PubSub_join_Results{Struct: r}, err
+}
+
+// PubSub_List is a list of PubSub.
+type PubSub_List = capnp.CapList[PubSub]
+
+// NewPubSub creates a new list of PubSub.
+func NewPubSub_List(s *capnp.Segment, sz int32) (PubSub_List, error) {
+	l, err := capnp.NewPointerList(s, sz)
+	return capnp.CapList[PubSub](l), err
 }
 
 type PubSub_join_Params struct{ capnp.Struct }

--- a/pkg/client/dialer_test.go
+++ b/pkg/client/dialer_test.go
@@ -191,13 +191,13 @@ func (mockPubSub) Join(ctx context.Context, call psapi.PubSub_join) error {
 	return fmt.Errorf("NOT IMPLEMENTED")
 }
 
-func (mockPubSub) Client() *capnp.Client {
+func (mockPubSub) Client() capnp.Client {
 	return psapi.PubSub_ServerToClient(mockPubSub{}, nil).Client
 }
 
 type mockView struct{}
 
-func (mockView) Client() *capnp.Client {
+func (mockView) Client() capnp.Client {
 	return clapi.View_ServerToClient(mockView{}, nil).Client
 }
 

--- a/pkg/client/pubsub.go
+++ b/pkg/client/pubsub.go
@@ -9,12 +9,12 @@ import (
 
 type Topic struct {
 	name   string
-	Client *capnp.Client
+	Client capnp.Client
 }
 
 // NewTopic populates a Topic with the supplied name and capability.
 // It does not validate the name.
-func NewTopic(c *capnp.Client, name string) Topic {
+func NewTopic(c capnp.Client, name string) Topic {
 	return Topic{
 		name:   name,
 		Client: c,
@@ -23,7 +23,7 @@ func NewTopic(c *capnp.Client, name string) Topic {
 
 // ResolveTopic populates a Topic from a raw capability client. It performs
 // an RPC call to determine the topic name and populates t with the result.
-func ResolveTopic(ctx context.Context, c *capnp.Client) (t Topic, err error) {
+func ResolveTopic(ctx context.Context, c capnp.Client) (t Topic, err error) {
 	t.Client = c
 	t.name, err = pubsub.Topic{Client: c}.Name(ctx)
 	return

--- a/pkg/vat/cap/anchor/anchor.go
+++ b/pkg/vat/cap/anchor/anchor.go
@@ -44,7 +44,7 @@ func NewAnchor(sched Scheduler, a anchor.Anchor_Server) AnchorServer {
 	}
 }
 
-func (a AnchorServer) Client() *capnp.Client {
+func (a AnchorServer) Client() capnp.Client {
 	switch s := a.anchor.(type) {
 	case *AnchorServer, AnchorServer:
 		c := anchor.Anchor_ServerToClient(s, a.Policy)

--- a/pkg/vat/cap/cluster/host.go
+++ b/pkg/vat/cap/cluster/host.go
@@ -28,7 +28,7 @@ type Dialer interface {
 
 type Host struct {
 	once   sync.Once
-	Client *capnp.Client
+	Client capnp.Client
 	Info   peer.AddrInfo
 }
 
@@ -48,7 +48,7 @@ func (h *Host) Walk(ctx context.Context, d Dialer, path anchor.Path) (anchor.Anc
 
 func (h *Host) resolve(ctx context.Context, d Dialer) cluster.Host {
 	h.once.Do(func() {
-		if h.Client == nil {
+		if h.Client == (capnp.Client{}) {
 			if conn, err := d.Dial(ctx, h.Info); err != nil {
 				h.Client = capnp.ErrorClient(err)
 			} else {
@@ -108,7 +108,7 @@ type HostServer struct {
 	anchor.AnchorServer
 }
 
-func (h *HostServer) Client() *capnp.Client {
+func (h *HostServer) Client() capnp.Client {
 	h.once.Do(func() {
 		if h.AnchorServer.Path().IsZero() {
 			h.AnchorServer = anchor.Root(h)

--- a/pkg/vat/cap/cluster/view.go
+++ b/pkg/vat/cap/cluster/view.go
@@ -44,7 +44,7 @@ type ViewServer struct {
 	*server.Policy
 }
 
-func (f ViewServer) Client() *capnp.Client {
+func (f ViewServer) Client() capnp.Client {
 	return api.View_ServerToClient(f, f.Policy).Client
 }
 

--- a/pkg/vat/cap/process/unix/process.go
+++ b/pkg/vat/cap/process/unix/process.go
@@ -132,7 +132,7 @@ func (h *handle) Signal(_ context.Context, call api.Unix_Proc_signal) (err error
 }
 
 func input(ctx context.Context, p iostream.Provider) io.Reader {
-	if p.Client == nil {
+	if p.Client == (capnp.Client{}) {
 		return nil
 	}
 
@@ -150,7 +150,7 @@ func input(ctx context.Context, p iostream.Provider) io.Reader {
 }
 
 func output(ctx context.Context, s iostream.Stream) io.Writer {
-	if s.Client == nil {
+	if s.Client == (capnp.Client{}) {
 		return nil
 	}
 

--- a/pkg/vat/cap/process/unix/unix.go
+++ b/pkg/vat/cap/process/unix/unix.go
@@ -40,7 +40,7 @@ type Server struct {
 	*server.Policy
 }
 
-func (s *Server) Client() *capnp.Client {
+func (s *Server) Client() capnp.Client {
 	return api.Executor_ServerToClient(s, s.Policy).Client
 }
 

--- a/pkg/vat/cap/pubsub/server.go
+++ b/pkg/vat/cap/pubsub/server.go
@@ -70,7 +70,7 @@ func (p *Provider) Close() (err error) {
 	return
 }
 
-func (p *Provider) Client() *capnp.Client {
+func (p *Provider) Client() capnp.Client {
 	return api.PubSub_ServerToClient(p, &defaultPolicy).Client
 }
 

--- a/pkg/vat/future.go
+++ b/pkg/vat/future.go
@@ -30,7 +30,7 @@ func (f Future) Await(ctx context.Context) error {
 
 type FuturePtr struct{ *capnp.Future }
 
-func (f FuturePtr) Client() *capnp.Client {
+func (f FuturePtr) Client() capnp.Client {
 	ptr, err := f.Ptr()
 	if err != nil {
 		return capnp.ErrorClient(err)

--- a/pkg/vat/vat.go
+++ b/pkg/vat/vat.go
@@ -33,7 +33,7 @@ type Capability interface {
 }
 
 type Bootstrapper interface {
-	Bootstrap() *capnp.Client
+	Bootstrap() capnp.Client
 }
 
 type Stream interface {
@@ -47,7 +47,7 @@ type ClientProvider interface {
 	// Client returns the client capability to be exported.  It is called
 	// once for each incoming Stream, so implementations may either share
 	// a single global object, or instantiate a new object for each call.
-	Client() *capnp.Client
+	Client() capnp.Client
 }
 
 type MetricReporter interface {
@@ -187,10 +187,10 @@ func match(c Capability, proto string) bool {
 	return false
 }
 
-func bootstrapper(c Capability) *capnp.Client {
+func bootstrapper(c Capability) capnp.Client {
 	if b, ok := c.(Bootstrapper); ok {
 		return b.Bootstrap()
 	}
 
-	return nil
+	return capnp.Client{}
 }


### PR DESCRIPTION
This PR upgrades the version of go-capnp to `3.0.0-alpha.4`, which includes minor bugfixes and minor breaking API changes.  The most notable API change is documented [here](https://github.com/capnproto/go-capnproto2/pull/260).

The diff is quite noisy, but reduces to exactly two things:

1. Update `go.mod` and `go.sum`
2. Refactor `*capnp.Client` into concrete `capnp.Client`. 