### PR TITLE
Increased discovery rate limiter

### DIFF
--- a/internal/cmd/client/discover.go
+++ b/internal/cmd/client/discover.go
@@ -60,7 +60,7 @@ func discover(c *cli.Context) error {
 	}
 
 	discoverer, err := bootutil.DialString(h, c.String("discover"),
-		socket.WithLogger(logger), socket.WithRateLimiter(socket.NewPacketLimiter(500, 8)))
+		socket.WithLogger(logger), socket.WithRateLimiter(socket.NewPacketLimiter(1000, 8)))
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/client/runtime.go
+++ b/internal/cmd/client/runtime.go
@@ -12,6 +12,7 @@ import (
 	"github.com/lthibault/log"
 	"github.com/urfave/cli/v2"
 	"github.com/wetware/casm/pkg/boot"
+	"github.com/wetware/casm/pkg/boot/socket"
 	bootutil "github.com/wetware/casm/pkg/boot/util"
 	logutil "github.com/wetware/ww/internal/util/log"
 	"github.com/wetware/ww/pkg/client"
@@ -84,7 +85,7 @@ func dialer(c *cli.Context, h host.Host, lx fx.Lifecycle) (d client.Dialer, err 
 		return
 	}
 
-	d.Boot, err = bootutil.DialString(h, c.String("discover"))
+	d.Boot, err = bootutil.DialString(h, c.String("discover"), socket.WithRateLimiter(socket.NewPacketLimiter(1000, 8)))
 	if err == nil {
 		if b, ok := d.Boot.(io.Closer); ok {
 			lx.Append(closer(b))

--- a/internal/runtime/network.go
+++ b/internal/runtime/network.go
@@ -28,6 +28,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/wetware/casm/pkg/boot"
+	"github.com/wetware/casm/pkg/boot/socket"
 	bootutil "github.com/wetware/casm/pkg/boot/util"
 	"github.com/wetware/casm/pkg/pex"
 	protoutil "github.com/wetware/casm/pkg/util/proto"
@@ -211,7 +212,7 @@ func bootstrap(config bootConfig) (b bootstrapper, err error) {
 	if config.CLI.IsSet("addr") {
 		b.Discovery, err = boot.NewStaticAddrStrings(config.CLI.StringSlice("addr")...)
 	} else {
-		b.Discovery, err = bootutil.ListenString(config.Host(), config.CLI.String("discover"))
+		b.Discovery, err = bootutil.ListenString(config.Host(), config.CLI.String("discover"), socket.WithRateLimiter(socket.NewPacketLimiter(1000, 8)))
 	}
 
 	if err == nil {


### PR DESCRIPTION
Current discovery takes too much time to scan a CIDR of /18, I increased the rate limiter for finding peers in the order of seconds, not minutes