### PR TITLE
Upgrade GitHub Actions to v3.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,9 +14,10 @@ jobs:
         go: [ '1.18', '1.19' ]
     name: Go ${{ matrix.go }}
     steps:
-      - uses: actions/checkout@v2
-      - name: Unit Tests
-        uses: actions/setup-go@v2
+      - name: Clone feature branch
+        uses: actions/checkout@v3
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
           go-version: ${{ matrix.go }}
-      - run: go test -v -cover -timeout 30s ./...
+      - run: go test -v -cover -race ./...


### PR DESCRIPTION
v2 is outputting a deprecation notice, so upgrade to v3.