### PR TITLE
Remove discovery.Limit from client.Dialer.join

### DIFF
--- a/pkg/client/dialer.go
+++ b/pkg/client/dialer.go
@@ -41,7 +41,7 @@ func (d Dialer) Dial(ctx context.Context) (*Node, error) {
 
 func (d Dialer) join(ctx context.Context) (n *Node, err error) {
 	var peers <-chan peer.AddrInfo
-	if peers, err = d.Boot.FindPeers(ctx, d.Vat.NS, discovery.Limit(100)); err != nil { // TODO: check the limit, and DONT DELETE!
+	if peers, err = d.Boot.FindPeers(ctx, d.Vat.NS); err != nil {
 		return nil, fmt.Errorf("discover: %w", err)
 	}
 


### PR DESCRIPTION
https://github.com/wetware/casm/pull/52 fixes issue where unlimited discovery streams were unbuffered, causing all but the first peer to be dropped during initial connection attempt.  As such, the workaround of setting a high limit is no longer needed.

Note that CASM now uses a static buffer with `cap=16`, so it is expected that slow consumers may miss all but the first 17 peers (first peer is immediately consumed from the channel, the buffer fills to cap=16).  In practice, this is not a problem since 16 peers is very generous for an initial bootstrap.