### PR TITLE
fixed code from meeting

### DIFF
--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -79,12 +79,14 @@ func setup() cli.BeforeFunc {
 }
 
 func teardown() cli.AfterFunc {
-	return func(c *cli.Context) error {
-		ctx, cancel := context.WithTimeout(
-			context.Background(),
-			app.StopTimeout())
-		defer cancel()
-
-		return app.Stop(ctx)
+	return func(c *cli.Context) (err error) {
+		if app != nil {
+			ctx, cancel := context.WithTimeout(
+				context.Background(),
+				app.StopTimeout())
+			defer cancel()
+			err = app.Stop(ctx)
+		}
+		return
 	}
 }


### PR DESCRIPTION
Also noticed that start.go and debug.go have the same exact teardown() as cluster.go