### PR TITLE
Dial move

### DIFF
--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -60,8 +60,6 @@ func Command() *cli.Command {
 		Usage:       "cli client for wetware clusters",
 		Aliases:     []string{"client"}, // TODO(soon):  deprecate
 		Flags:       flags,
-		Before:      setup(),
-		After:       teardown(),
 		Subcommands: subcommands,
 	}
 }
@@ -79,7 +77,9 @@ func setup() cli.BeforeFunc {
 			app.StartTimeout())
 		defer cancel()
 
-		node, err = dialer.Dial(ctx)
+		if node, err = dialer.Dial(ctx); err != nil {
+			return
+		}
 
 		return app.Start(ctx)
 	}

--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -78,6 +78,7 @@ func setup() cli.BeforeFunc {
 	}
 }
 
+// test
 func teardown() cli.AfterFunc {
 	return func(c *cli.Context) (err error) {
 		if app != nil {

--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -74,7 +74,7 @@ func setup() cli.BeforeFunc {
 
 		ctx, cancel := context.WithTimeout(
 			c.Context,
-			app.StartTimeout())
+			c.Duration("timeout"))
 		defer cancel()
 
 		if node, err = dialer.Dial(ctx); err != nil {

--- a/internal/cmd/cluster/cluster.go
+++ b/internal/cmd/cluster/cluster.go
@@ -26,38 +26,42 @@ var subcommands = []*cli.Command{
 	// Discover(),
 }
 
+var flags = []cli.Flag{
+	&cli.StringSliceFlag{
+		Name:    "addr",
+		Aliases: []string{"a"},
+		Usage:   "static bootstrap `ADDR`",
+		EnvVars: []string{"WW_ADDR"},
+	},
+	&cli.StringFlag{
+		Name:    "discover",
+		Aliases: []string{"d"},
+		Usage:   "bootstrap discovery `ADDR`",
+		Value:   "/ip4/228.8.8.8/udp/8822/multicast/lo0",
+		EnvVars: []string{"WW_DISCOVER"},
+	},
+	&cli.StringFlag{
+		Name:    "ns",
+		Usage:   "cluster namespace",
+		Value:   "ww",
+		EnvVars: []string{"WW_NS"},
+	},
+	&cli.DurationFlag{
+		Name:    "timeout",
+		Usage:   "dial timeout",
+		Value:   time.Second * 15,
+		EnvVars: []string{"WW_CLIENT_TIMEOUT"},
+	},
+}
+
 func Command() *cli.Command {
 	return &cli.Command{
-		Name:    "cluster",
-		Usage:   "cli client for wetware clusters",
-		Aliases: []string{"client"}, // TODO(soon):  deprecate
-		Flags: []cli.Flag{
-			&cli.StringSliceFlag{
-				Name:    "addr",
-				Aliases: []string{"a"},
-				Usage:   "static bootstrap `ADDR`",
-				EnvVars: []string{"WW_ADDR"},
-			},
-			&cli.StringFlag{
-				Name:    "discover",
-				Aliases: []string{"d"},
-				Usage:   "bootstrap discovery `ADDR`",
-				Value:   "/ip4/228.8.8.8/udp/8822/multicast/lo0",
-				EnvVars: []string{"WW_DISCOVER"},
-			},
-			&cli.StringFlag{
-				Name:    "ns",
-				Usage:   "cluster namespace",
-				Value:   "ww",
-				EnvVars: []string{"WW_NS"},
-			},
-			&cli.DurationFlag{
-				Name:    "timeout",
-				Usage:   "dial timeout",
-				Value:   time.Second * 15,
-				EnvVars: []string{"WW_CLIENT_TIMEOUT"},
-			},
-		},
+		Name:        "cluster",
+		Usage:       "cli client for wetware clusters",
+		Aliases:     []string{"client"}, // TODO(soon):  deprecate
+		Flags:       flags,
+		Before:      setup(),
+		After:       teardown(),
 		Subcommands: subcommands,
 	}
 }
@@ -83,14 +87,10 @@ func setup() cli.BeforeFunc {
 
 func teardown() cli.AfterFunc {
 	return func(c *cli.Context) (err error) {
-		// if app != nil {
 		ctx, cancel := context.WithTimeout(
 			context.Background(),
 			app.StopTimeout())
 		defer cancel()
 		return app.Stop(ctx)
-		//err = app.Stop(ctx)
-		//}
-		//return
 	}
 }

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -16,7 +16,6 @@ func Client(opt ...Option) fx.Option {
 		c.Vat(),
 		c.System(),
 		c.ClientBootstrap(),
-		//fx.Provide(newClientNode)
 	)
 }
 

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -1,10 +1,7 @@
 package runtime
 
 import (
-	"context"
-
 	casm "github.com/wetware/casm/pkg"
-	"github.com/wetware/ww/pkg/client"
 	"go.uber.org/fx"
 )
 
@@ -19,15 +16,16 @@ func Client(opt ...Option) fx.Option {
 		c.Vat(),
 		c.System(),
 		c.ClientBootstrap(),
-		fx.Provide(newClientNode))
+		//fx.Provide(newClientNode)
+	)
 }
 
-func newClientNode(env Env, d client.Dialer) (*client.Node, error) {
-	ctx, cancel := context.WithTimeout(env.Context(), env.Duration("timeout"))
-	defer cancel()
+// func newClientNode(env Env, d client.Dialer) (*client.Node, error) {
+// 	ctx, cancel := context.WithTimeout(env.Context(), env.Duration("timeout"))
+// 	defer cancel()
 
-	return d.Dial(ctx)
-}
+// 	return d.Dial(ctx)
+// }
 
 func clientDefaults(opt []Option) []Option {
 	return append([]Option{

--- a/internal/runtime/client.go
+++ b/internal/runtime/client.go
@@ -20,13 +20,6 @@ func Client(opt ...Option) fx.Option {
 	)
 }
 
-// func newClientNode(env Env, d client.Dialer) (*client.Node, error) {
-// 	ctx, cancel := context.WithTimeout(env.Context(), env.Duration("timeout"))
-// 	defer cancel()
-
-// 	return d.Dial(ctx)
-// }
-
 func clientDefaults(opt []Option) []Option {
 	return append([]Option{
 		WithHostConfig(casm.Client),


### PR DESCRIPTION
#65 

**Changed:**
- Moved the call to Dial from [newClientNode](https://github.com/wetware/ww/blob/master/internal/runtime/client.go#L25-L30) in `internal/cmd/cluster/cluster.go` to [setup](https://github.com/wetware/ww/blob/master/internal/cmd/cluster/cluster.go#L64-L79) in `internal/cmd/cluster/cluster.go`.
    - Now fail gracefully when trying to publish message to topic without any ww start instances. 
- Added `Before` and `After` fields to the cluster `cli.Command`
    - Now no panic when type in something wrong like `ww cluster publish`

**Uncertainties**
- I removed the `app != nil` check from teardown under the assumption that it was a temporary fix.
- I'm pretty sure that the error returned from `Dial()` is being lost, but not really sure how that can be included. 
