### PR TITLE
Add streaming send capability to csp.Chan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/thejerf/suture/v4 v4.0.2
-	github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2
+	github.com/wetware/casm v0.0.0-20221217013037-effefec91c4e
 	golang.org/x/sync v0.1.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/wetware/ww
 go 1.19
 
 require (
-	capnproto.org/go/capnp/v3 v3.0.0-alpha.15
+	capnproto.org/go/capnp/v3 v3.0.0-alpha.16
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/huin/goupnp v1.0.3 // indirect
@@ -38,7 +38,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/thejerf/suture/v4 v4.0.2
-	github.com/wetware/casm v0.0.0-20221216231503-0ad175726c4e
+	github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2
 	golang.org/x/sync v0.1.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -466,8 +466,8 @@ github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6f
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
-github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2 h1:9WooFwRyiLaJvn5IQXEauNHsa4D1/LCJyMhQM7ijOMg=
-github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2/go.mod h1:QYYRCTU86AuqIp8TL7YaHP2AZaZCtpwnVaslCMeVm+I=
+github.com/wetware/casm v0.0.0-20221217013037-effefec91c4e h1:9RNLWE8Ja8B9rVDRk6WaPti+rcXnQU8WDtDP+3M6uY4=
+github.com/wetware/casm v0.0.0-20221217013037-effefec91c4e/go.mod h1:QYYRCTU86AuqIp8TL7YaHP2AZaZCtpwnVaslCMeVm+I=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-capnproto.org/go/capnp/v3 v3.0.0-alpha.15 h1:tpe21JFekBInlzUeQ5FACwHSbOfdqAKLZNfiNchywNU=
-capnproto.org/go/capnp/v3 v3.0.0-alpha.15/go.mod h1:Dynqh9/LE2Wy7jYd2wIoYgqFwh3hZHCmG7j6/uCWX6c=
+capnproto.org/go/capnp/v3 v3.0.0-alpha.16 h1:lxknpi4QotPwh4KXgmORjoZ/glD1bcEyHXu1yBgeBfk=
+capnproto.org/go/capnp/v3 v3.0.0-alpha.16/go.mod h1:Dynqh9/LE2Wy7jYd2wIoYgqFwh3hZHCmG7j6/uCWX6c=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.31.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
@@ -466,8 +466,8 @@ github.com/urfave/cli/v2 v2.23.7/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6f
 github.com/viant/assertly v0.4.8/go.mod h1:aGifi++jvCrUaklKEKT0BU95igDNaqkvz+49uaYMPRU=
 github.com/viant/toolbox v0.24.0/go.mod h1:OxMCG57V0PXuIP2HNQrtJf2CjqdmbrOx5EkMILuUhzM=
 github.com/warpfork/go-wish v0.0.0-20200122115046-b9ea61034e4a h1:G++j5e0OC488te356JvdhaM8YS6nMsjLAYF7JxCv07w=
-github.com/wetware/casm v0.0.0-20221216231503-0ad175726c4e h1:eh2XAsZMnTTcXa8VXccUBCEpynAt8SyD1uEfr7hUSI4=
-github.com/wetware/casm v0.0.0-20221216231503-0ad175726c4e/go.mod h1:6BDTdyFcgbD04P8krrRCHjAQ+Nizg833QPi8FriJTJw=
+github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2 h1:9WooFwRyiLaJvn5IQXEauNHsa4D1/LCJyMhQM7ijOMg=
+github.com/wetware/casm v0.0.0-20221217012423-dfeda06a92e2/go.mod h1:QYYRCTU86AuqIp8TL7YaHP2AZaZCtpwnVaslCMeVm+I=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/whyrusleeping/timecache v0.0.0-20160911033111-cfcb2f1abfee h1:lYbXeSvJi5zk5GLKVuid9TVjS9a0OmLIDKTfoZBL6Ow=

--- a/pkg/csp/chan.go
+++ b/pkg/csp/chan.go
@@ -7,7 +7,10 @@ import (
 	"errors"
 
 	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/exp/clock"
+	"capnproto.org/go/capnp/v3/flowcontrol/bbr"
 	casm "github.com/wetware/casm/pkg"
+	"github.com/wetware/casm/pkg/util/stream"
 	"github.com/wetware/ww/internal/api/channel"
 )
 
@@ -98,6 +101,13 @@ func (c Chan) Recv(ctx context.Context) (casm.FuturePtr, capnp.ReleaseFunc) {
 	return Recver(c).Recv(ctx)
 }
 
+// NewStream for the sender.   This will overwrite the existing
+// flow limiter. Callers SHOULD NOT create more than one stream
+// for a given sender.
+func (c Chan) NewStream(ctx context.Context) SendStream {
+	return Sender(c).NewStream(ctx)
+}
+
 func (c Chan) AddRef() Chan {
 	return Chan(capnp.Client(c).AddRef())
 }
@@ -146,6 +156,13 @@ func (sc SendCloser) Send(ctx context.Context, v Value) (casm.Future, capnp.Rele
 	return Sender(sc).Send(ctx, v)
 }
 
+// NewStream for the sender.   This will overwrite the existing
+// flow limiter. Callers SHOULD NOT create more than one stream
+// for a given sender.
+func (sc SendCloser) NewStream(ctx context.Context) SendStream {
+	return Sender(sc).NewStream(ctx)
+}
+
 func (sc SendCloser) AddRef() SendCloser {
 	return SendCloser(capnp.Client(sc).AddRef())
 }
@@ -185,6 +202,19 @@ func NewSender(s SendServer) Sender {
 func (s Sender) Send(ctx context.Context, v Value) (casm.Future, capnp.ReleaseFunc) {
 	f, release := channel.Sender(s).Send(ctx, v)
 	return casm.Future(f), release
+}
+
+// NewStream for the sender.   This will overwrite the existing
+// flow limiter. Callers SHOULD NOT create more than one stream
+// for a given sender.
+func (s Sender) NewStream(ctx context.Context) SendStream {
+	sender := channel.Sender(s)
+	sender.SetFlowLimiter(bbr.NewLimiter(clock.System))
+
+	return SendStream{
+		ctx:    ctx,
+		stream: stream.New(channel.Sender(s).Send),
+	}
 }
 
 func (s Sender) AddRef() Sender {

--- a/pkg/csp/chan.go
+++ b/pkg/csp/chan.go
@@ -213,7 +213,7 @@ func (s Sender) NewStream(ctx context.Context) SendStream {
 
 	return SendStream{
 		ctx:    ctx,
-		stream: stream.New(channel.Sender(s).Send),
+		stream: stream.New(sender.Send),
 	}
 }
 

--- a/pkg/csp/stream.go
+++ b/pkg/csp/stream.go
@@ -3,8 +3,6 @@ package csp
 import (
 	"context"
 
-	"capnproto.org/go/capnp/v3/exp/clock"
-	"capnproto.org/go/capnp/v3/flowcontrol/bbr"
 	"github.com/wetware/casm/pkg/util/stream"
 	"github.com/wetware/ww/internal/api/channel"
 )
@@ -12,19 +10,6 @@ import (
 type SendStream struct {
 	ctx    context.Context
 	stream *stream.Stream[channel.Sender_send_Params]
-}
-
-// NewStream for the sender.   This will overwrite the existing
-// flow limiter. Callers SHOULD NOT create more than one stream
-// for a given sender.
-func (s Sender) NewStream(ctx context.Context) SendStream {
-	sender := channel.Sender(s)
-	sender.SetFlowLimiter(bbr.NewLimiter(clock.System))
-
-	return SendStream{
-		ctx:    ctx,
-		stream: stream.New(channel.Sender(s).Send),
-	}
 }
 
 func (s SendStream) Send(v Value) (err error) {

--- a/pkg/csp/stream.go
+++ b/pkg/csp/stream.go
@@ -1,0 +1,40 @@
+package csp
+
+import (
+	"context"
+
+	"capnproto.org/go/capnp/v3/exp/clock"
+	"capnproto.org/go/capnp/v3/flowcontrol/bbr"
+	"github.com/wetware/casm/pkg/util/stream"
+	"github.com/wetware/ww/internal/api/channel"
+)
+
+type SendStream struct {
+	ctx    context.Context
+	stream *stream.Stream[channel.Sender_send_Params]
+}
+
+// NewStream for the sender.   This will overwrite the existing
+// flow limiter. Callers SHOULD NOT create more than one stream
+// for a given sender.
+func (s Sender) NewStream(ctx context.Context) SendStream {
+	sender := channel.Sender(s)
+	sender.SetFlowLimiter(bbr.NewLimiter(clock.System))
+
+	return SendStream{
+		ctx:    ctx,
+		stream: stream.New(channel.Sender(s).Send),
+	}
+}
+
+func (s SendStream) Send(v Value) (err error) {
+	if s.stream.Call(s.ctx, v); !s.stream.Open() {
+		err = s.Close()
+	}
+
+	return
+}
+
+func (s SendStream) Close() error {
+	return s.stream.Wait()
+}

--- a/pkg/csp/stream_test.go
+++ b/pkg/csp/stream_test.go
@@ -1,0 +1,89 @@
+package csp_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	mock_csp "github.com/wetware/ww/internal/mock/pkg/csp"
+	"github.com/wetware/ww/pkg/csp"
+)
+
+func TestSendStream(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	server := mock_csp.NewMockSendServer(ctrl)
+	server.EXPECT().
+		Send(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(128)
+
+	sender := csp.NewSender(server)
+	defer sender.Release()
+
+	stream := sender.NewStream(context.Background())
+	for i := 0; i < 128; i++ {
+		err := stream.Send(csp.Text("hello, world!"))
+		require.NoError(t, err, "should send text")
+	}
+
+	err := stream.Close()
+	assert.NoError(t, err, "should close gracefully")
+}
+
+func TestSendStream_Error(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	want := errors.New("test")
+
+	server := mock_csp.NewMockSendServer(ctrl)
+	server.EXPECT().
+		Send(gomock.Any(), gomock.Any()).
+		Return(nil).
+		Times(64)
+	server.EXPECT().
+		Send(gomock.Any(), gomock.Any()).
+		Return(want).
+		Times(1)
+	server.EXPECT().
+		Send(gomock.Any(), gomock.Any()).
+		Return(nil).
+		MaxTimes(64)
+
+	sender := csp.NewSender(server)
+	defer sender.Release()
+
+	stream := sender.NewStream(context.Background())
+	for i := 0; i < 64; i++ {
+		err := stream.Send(csp.Text("hello, world!"))
+		require.NoError(t, err, "should send text")
+	}
+
+	// The next call will trigger the error, but it might
+	// not be detected synchronously.   We have no way of
+	// knowing which of these calls will detect the error.
+	for i := 0; i < 64; i++ {
+		// Maximize the chance that of detecting the error
+		// in-flight.  This helps with code coverage.
+		time.Sleep(time.Millisecond)
+
+		err := stream.Send(csp.Text("hello, world!"))
+		if err != nil {
+			require.ErrorIs(t, err, want, "should return error")
+		}
+	}
+
+	err := stream.Close()
+	require.ErrorIs(t, err, want, "should return error")
+}


### PR DESCRIPTION
This PR adds a `NewStream` method to `csp.Chan` and its derivatives.  This adds support for [flow-controlled streams](https://capnproto.org/news/2020-04-23-capnproto-0.8.html) to channels, which should greatly improve performance for large volumes of concurrent sends.

@mikelsr This is especially relevant to your work on processes, since `iostream` is implemented using `csp.Chan` under the hood.  Use of `csp.SendStream` in `iostream` will be submitted in a separate PR.

(cc @aratz-lasa @evan-schott for general awareness.  Code-review & feedback is most welcome.)