### PR TITLE
Replace casm.Future with csp.Future.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/tetratelabs/wazero v1.0.0-pre.4
 	github.com/thejerf/suture/v4 v4.0.2
-	github.com/wetware/casm v0.0.0-20230221204520-1957fd184f20
+	github.com/wetware/casm v0.0.0-20230224203443-f715090fc92c
 	golang.org/x/sync v0.1.0
 	gopkg.in/alexcesaro/statsd.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -507,6 +507,8 @@ github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0 h1:GDDkbFiaK8jsSD
 github.com/warpfork/go-wish v0.0.0-20220906213052-39a1cc7a02d0/go.mod h1:x6AKhvSSexNrVSrViXSHUEbICjmGXhtgABaHIySUSGw=
 github.com/wetware/casm v0.0.0-20230221204520-1957fd184f20 h1:TYrOgmbPbxUO4PqjwRF2foxpKoqDdu2fRvmAd1ptKTI=
 github.com/wetware/casm v0.0.0-20230221204520-1957fd184f20/go.mod h1:POhb5OT6s9paBkfl2/GVEUPYFx0WVLy1t9u9KprDMOU=
+github.com/wetware/casm v0.0.0-20230224203443-f715090fc92c h1:vOxUhNnjyzBuIq0/nhdlyoVj8gug4SQlgtojo0Pg8Bo=
+github.com/wetware/casm v0.0.0-20230224203443-f715090fc92c/go.mod h1:POhb5OT6s9paBkfl2/GVEUPYFx0WVLy1t9u9KprDMOU=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1 h1:EKhdznlJHPMoKr0XTrX+IlJs1LH3lyx2nfr1dOlZ79k=
 github.com/whyrusleeping/go-keyspace v0.0.0-20160322163242-5b898ac5add1/go.mod h1:8UvriyWtv5Q5EOgjHaSseUEdkQfvwFv1I/In/O2M9gc=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=

--- a/pkg/csp/chan.go
+++ b/pkg/csp/chan.go
@@ -82,7 +82,9 @@ func Text(s string) Value {
 	}
 }
 
-// Future result from a Chan operation.
+// Future result from a Chan operation. It is a specialized instance
+// of a casm.Future that provides typed methods for common capnp.Ptr
+// types.
 type Future casm.Future
 
 func (f Future) Await(ctx context.Context) (val capnp.Ptr, err error) {


### PR DESCRIPTION
Follow up of https://github.com/wetware/casm/pull/71.  Replaces use of `casm.FuturePtr` in `csp` package with `csp.Future`, which is actually correct.

This PR is in draft until https://github.com/wetware/casm/pull/71 is merged, and the local version of CASM can be upgraded.