### PR TITLE
deps: updates wazero to 1.0.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/lthibault/go-libp2p-inproc-transport v0.4.0
 	github.com/multiformats/go-multistream v0.4.1
 	github.com/stretchr/testify v1.8.2
-	github.com/tetratelabs/wazero v1.0.0-rc.1
+	github.com/tetratelabs/wazero v1.0.1
 	github.com/thejerf/suture/v4 v4.0.2
 	github.com/wetware/casm v0.0.0-20230328202356-84a9cb53de27
 	golang.org/x/sync v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -484,8 +484,8 @@ github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
-github.com/tetratelabs/wazero v1.0.0-rc.1 h1:ytecMV5Ue0BwezjKh/cM5yv1Mo49ep2R2snSsQUyToc=
-github.com/tetratelabs/wazero v1.0.0-rc.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
+github.com/tetratelabs/wazero v1.0.1 h1:xyWBoGyMjYekG3mEQ/W7xm9E05S89kJ/at696d/9yuc=
+github.com/tetratelabs/wazero v1.0.1/go.mod h1:wYx2gNRg8/WihJfSDxA1TIL8H+GkfLYm+bIfbblu9VQ=
 github.com/thejerf/suture/v4 v4.0.2 h1:VxIH/J8uYvqJY1+9fxi5GBfGRkRZ/jlSOP6x9HijFQc=
 github.com/thejerf/suture/v4 v4.0.2/go.mod h1:g0e8vwskm9tI0jRjxrnA6lSr0q6OfPdWJVX7G5bVWRs=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=

--- a/pkg/process/executor_test.go
+++ b/pkg/process/executor_test.go
@@ -34,7 +34,6 @@ func TestExecutor(t *testing.T) {
 	ee, ok := err.(*sys.ExitError)
 	require.True(t, ok, "should return sys.ExitError")
 	assert.Equal(t, uint32(99), ee.ExitCode())
-	assert.NotEmpty(t, ee.ModuleName())
 }
 
 func testdata() []byte {

--- a/pkg/process/process.go
+++ b/pkg/process/process.go
@@ -63,11 +63,7 @@ func (p Proc) Wait(ctx context.Context) error {
 		return nil
 
 	case api.Error_Which_exitErr:
-		mod, err := e.ExitErr().Module()
-		if err != nil {
-			return err
-		}
-		return sys.NewExitError(mod, e.ExitErr().Code())
+		return sys.NewExitError(e.ExitErr().Code())
 	}
 
 	return fmt.Errorf("unknown error type: %d", e.Which())
@@ -169,7 +165,7 @@ func (as *procHandle) Bind(res api.Process_wait_Results) error {
 	ee := state.Err.(*sys.ExitError)
 	e.SetExitErr()
 	e.ExitErr().SetCode(ee.ExitCode())
-	return e.ExitErr().SetModule(ee.ModuleName())
+	return nil
 }
 
 // Load the current state atomically.  The resulting resulting state


### PR DESCRIPTION
This updates [wazero](https://wazero.io/) to [1.0.0](https://github.com/tetratelabs/wazero/releases/tag/v1.0.0) which begins our compatibility promise.

On behalf of everyone in the community, I want to thank you for trying wazero before we became stable. We will not raise unsolicited pull requests anymore. That said, if any update gives you problems, please feel free to contact [us](https://wazero.io/community/) on slack or via a GitHub issue.

Finally, if you would like to share your work, feel free to update our [users page](https://github.com/tetratelabs/wazero/blob/main/site/content/community/users.md)!