### PR TITLE
Simplify exit error schema.

### DIFF
--- a/api/process.capnp
+++ b/api/process.capnp
@@ -15,16 +15,5 @@ interface Executor {
 interface Process {
     start  @0 () -> ();
     stop   @1 () -> ();
-    wait   @2 () -> (error :Error);
-}
-
-struct Error {
-    union {
-        none       @0 :Void;
-        msg        @1 :Text;
-        exitErr       :group {
-            code   @2 :UInt32;
-            module @3 :Text;
-        }
-    }
+    wait   @2 () -> (exitCode :UInt32);
 }

--- a/internal/api/process/process.capnp.go
+++ b/internal/api/process/process.capnp.go
@@ -10,7 +10,6 @@ import (
 	server "capnproto.org/go/capnp/v3/server"
 	context "context"
 	fmt "fmt"
-	strconv "strconv"
 )
 
 type Executor capnp.Client
@@ -578,7 +577,7 @@ func (c Process_wait) Args() Process_wait_Params {
 
 // AllocResults allocates the results struct.
 func (c Process_wait) AllocResults() (Process_wait_Results, error) {
-	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	r, err := c.Call.AllocResults(capnp.ObjectSize{DataSize: 8, PointerCount: 0})
 	return Process_wait_Results(r), err
 }
 
@@ -922,12 +921,12 @@ type Process_wait_Results capnp.Struct
 const Process_wait_Results_TypeID = 0x9d6074459fa0602b
 
 func NewProcess_wait_Results(s *capnp.Segment) (Process_wait_Results, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0})
 	return Process_wait_Results(st), err
 }
 
 func NewRootProcess_wait_Results(s *capnp.Segment) (Process_wait_Results, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1})
+	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0})
 	return Process_wait_Results(st), err
 }
 
@@ -963,28 +962,12 @@ func (s Process_wait_Results) Message() *capnp.Message {
 func (s Process_wait_Results) Segment() *capnp.Segment {
 	return capnp.Struct(s).Segment()
 }
-func (s Process_wait_Results) Error() (Error, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return Error(p.Struct()), err
+func (s Process_wait_Results) ExitCode() uint32 {
+	return capnp.Struct(s).Uint32(0)
 }
 
-func (s Process_wait_Results) HasError() bool {
-	return capnp.Struct(s).HasPtr(0)
-}
-
-func (s Process_wait_Results) SetError(v Error) error {
-	return capnp.Struct(s).SetPtr(0, capnp.Struct(v).ToPtr())
-}
-
-// NewError sets the error field to a newly
-// allocated Error struct, preferring placement in s's segment.
-func (s Process_wait_Results) NewError() (Error, error) {
-	ss, err := NewError(capnp.Struct(s).Segment())
-	if err != nil {
-		return Error{}, err
-	}
-	err = capnp.Struct(s).SetPtr(0, capnp.Struct(ss).ToPtr())
-	return ss, err
+func (s Process_wait_Results) SetExitCode(v uint32) {
+	capnp.Struct(s).SetUint32(0, v)
 }
 
 // Process_wait_Results_List is a list of Process_wait_Results.
@@ -992,7 +975,7 @@ type Process_wait_Results_List = capnp.StructList[Process_wait_Results]
 
 // NewProcess_wait_Results creates a new list of Process_wait_Results.
 func NewProcess_wait_Results_List(s *capnp.Segment, sz int32) (Process_wait_Results_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 0, PointerCount: 1}, sz)
+	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 0}, sz)
 	return capnp.StructList[Process_wait_Results](l), err
 }
 
@@ -1003,241 +986,53 @@ func (f Process_wait_Results_Future) Struct() (Process_wait_Results, error) {
 	p, err := f.Future.Ptr()
 	return Process_wait_Results(p.Struct()), err
 }
-func (p Process_wait_Results_Future) Error() Error_Future {
-	return Error_Future{Future: p.Future.Field(0, nil)}
-}
 
-type Error capnp.Struct
-type Error_exitErr Error
-type Error_Which uint16
-
-const (
-	Error_Which_none    Error_Which = 0
-	Error_Which_msg     Error_Which = 1
-	Error_Which_exitErr Error_Which = 2
-)
-
-func (w Error_Which) String() string {
-	const s = "nonemsgexitErr"
-	switch w {
-	case Error_Which_none:
-		return s[0:4]
-	case Error_Which_msg:
-		return s[4:7]
-	case Error_Which_exitErr:
-		return s[7:14]
-
-	}
-	return "Error_Which(" + strconv.FormatUint(uint64(w), 10) + ")"
-}
-
-// Error_TypeID is the unique identifier for the type Error.
-const Error_TypeID = 0xd6be5a33d8c2c538
-
-func NewError(s *capnp.Segment) (Error, error) {
-	st, err := capnp.NewStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
-	return Error(st), err
-}
-
-func NewRootError(s *capnp.Segment) (Error, error) {
-	st, err := capnp.NewRootStruct(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1})
-	return Error(st), err
-}
-
-func ReadRootError(msg *capnp.Message) (Error, error) {
-	root, err := msg.Root()
-	return Error(root.Struct()), err
-}
-
-func (s Error) String() string {
-	str, _ := text.Marshal(0xd6be5a33d8c2c538, capnp.Struct(s))
-	return str
-}
-
-func (s Error) EncodeAsPtr(seg *capnp.Segment) capnp.Ptr {
-	return capnp.Struct(s).EncodeAsPtr(seg)
-}
-
-func (Error) DecodeFromPtr(p capnp.Ptr) Error {
-	return Error(capnp.Struct{}.DecodeFromPtr(p))
-}
-
-func (s Error) ToPtr() capnp.Ptr {
-	return capnp.Struct(s).ToPtr()
-}
-
-func (s Error) Which() Error_Which {
-	return Error_Which(capnp.Struct(s).Uint16(0))
-}
-func (s Error) IsValid() bool {
-	return capnp.Struct(s).IsValid()
-}
-
-func (s Error) Message() *capnp.Message {
-	return capnp.Struct(s).Message()
-}
-
-func (s Error) Segment() *capnp.Segment {
-	return capnp.Struct(s).Segment()
-}
-func (s Error) SetNone() {
-	capnp.Struct(s).SetUint16(0, 0)
-
-}
-
-func (s Error) Msg() (string, error) {
-	if capnp.Struct(s).Uint16(0) != 1 {
-		panic("Which() != msg")
-	}
-	p, err := capnp.Struct(s).Ptr(0)
-	return p.Text(), err
-}
-
-func (s Error) HasMsg() bool {
-	if capnp.Struct(s).Uint16(0) != 1 {
-		return false
-	}
-	return capnp.Struct(s).HasPtr(0)
-}
-
-func (s Error) MsgBytes() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return p.TextBytes(), err
-}
-
-func (s Error) SetMsg(v string) error {
-	capnp.Struct(s).SetUint16(0, 1)
-	return capnp.Struct(s).SetText(0, v)
-}
-
-func (s Error) ExitErr() Error_exitErr { return Error_exitErr(s) }
-
-func (s Error) SetExitErr() {
-	capnp.Struct(s).SetUint16(0, 2)
-}
-
-func (s Error_exitErr) IsValid() bool {
-	return capnp.Struct(s).IsValid()
-}
-
-func (s Error_exitErr) Message() *capnp.Message {
-	return capnp.Struct(s).Message()
-}
-
-func (s Error_exitErr) Segment() *capnp.Segment {
-	return capnp.Struct(s).Segment()
-}
-func (s Error_exitErr) Code() uint32 {
-	return capnp.Struct(s).Uint32(4)
-}
-
-func (s Error_exitErr) SetCode(v uint32) {
-	capnp.Struct(s).SetUint32(4, v)
-}
-
-func (s Error_exitErr) Module() (string, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return p.Text(), err
-}
-
-func (s Error_exitErr) HasModule() bool {
-	return capnp.Struct(s).HasPtr(0)
-}
-
-func (s Error_exitErr) ModuleBytes() ([]byte, error) {
-	p, err := capnp.Struct(s).Ptr(0)
-	return p.TextBytes(), err
-}
-
-func (s Error_exitErr) SetModule(v string) error {
-	return capnp.Struct(s).SetText(0, v)
-}
-
-// Error_List is a list of Error.
-type Error_List = capnp.StructList[Error]
-
-// NewError creates a new list of Error.
-func NewError_List(s *capnp.Segment, sz int32) (Error_List, error) {
-	l, err := capnp.NewCompositeList(s, capnp.ObjectSize{DataSize: 8, PointerCount: 1}, sz)
-	return capnp.StructList[Error](l), err
-}
-
-// Error_Future is a wrapper for a Error promised by a client call.
-type Error_Future struct{ *capnp.Future }
-
-func (f Error_Future) Struct() (Error, error) {
-	p, err := f.Future.Ptr()
-	return Error(p.Struct()), err
-}
-func (p Error_Future) ExitErr() Error_exitErr_Future { return Error_exitErr_Future{p.Future} }
-
-// Error_exitErr_Future is a wrapper for a Error_exitErr promised by a client call.
-type Error_exitErr_Future struct{ *capnp.Future }
-
-func (f Error_exitErr_Future) Struct() (Error_exitErr, error) {
-	p, err := f.Future.Ptr()
-	return Error_exitErr(p.Struct()), err
-}
-
-const schema_9a51e53177277763 = "x\xda|\x94_\x88\x1bU\x14\xc6\xcfw\xef$\x93b" +
-	"\xd2\xec\xed\xa4\x15\xfb\x12\xba\xaeh#M\x93\xae\x82-" +
-	"\x96\x8d\xd5a\xb1X\x9c+\xf8R\xa8t\xcc\x0e\x1aH" +
-	"2\xe1\xce\x84l\x9f\x8a \xf4]\x11A\x11K\xa1\xd4" +
-	"\x82kK\xf5iEAa\xf1UVqE\x1f\x84\x15" +
-	"A|XT\xf0aA\xbdr'\x7f\xd7\xec\xee[n" +
-	"N\xeew~\xe7\xfb\xceM\xe5\x06jV5w-E" +
-	"L\xd6Ri\xbd\x91\xfa+\\\xf1\xff~\x9dd\x01\xd0" +
-	"O\xac}\xf9\xfd\xfc\xc5\xcf\xbf\xa3\xc3\xb0A\xe4\xdcf" +
-	"\x9b\x04g\x85\xf5\x08\xfa\xd1\xcb\xd7\xdfw\xe3\xcb\xef\x91" +
-	"8\x02\xa2\x14l\xa2\xf9\x03\xfc(\x08\x8e\xe0\x0b\x04\xbd" +
-	"\xde}\xed\xe6\xeaK\xe5;$\x0er]\xef=\xdc\xab" +
-	"\xfe\"\xdf!\x82S\xe5\xab\xcein\x139\x8f\xf3E" +
-	"\xe7\x92\xf9\xa4\xdf\xfdz\xfd\xd6\xdd#\xcf\x7fJ\xe2\xfe" +
-	"\x91\x9a\xcbKF\xedB\xa2\xb6\xf5\xf6\xb7\xd1\xbdW\xab" +
-	"k\xfdv\x96\xa9\xb7L7K\xffz\xed\x8b\xf4O\xdd" +
-	"\x93\xeb\x13\x95\x17\xf9!S\x19\xe1\xcb\x83\xc0\x18\xc1\x85" +
-	"\xcd\x89\x9c\xb3\xfc\x86\xe3&\x18O\xf1;\x04\xfd\xe1b" +
-	"e\xee\xfa'\xa5\x8d\x09\x9d\xcf\xf8\xac\xd1\x99O?\xf4" +
-	"\xc17\xbf?\xf8\xc3\xd4$7\xf9=g%\x91\xb8\xcd" +
-	"\xbfr\x8e\x99;z\xf1\xd2\xc9\xbb\x0f|tkkB" +
-	"\xe6\x80\x95\xe0\x1cz\xf3\x8d\xb7~;{\xdf\x9f\x83\x19" +
-	"\x99)\xfda:\xc0\xd9\xe6\xc6\xd2\x9f?\xfe1\xb3y" +
-	"\xbe\xb1=q\xd5\xb7\x8e\x82*\xba\xa3\xc2z\x10Ee" +
-	"V\xf7;\xed\xce\x19W\xa9P\x95\x83\xe5Fl\xbbJ" +
-	"\xc9\x0c\xb7fP\x00#\x12\xc7KDr\x8eCV\x18" +
-	"\x80\x028\x918q\x86H>\xc2!\x1fc\xc8\xd7\xc3" +
-	"\xa5\x00\x19b\xc8\x10\x16Z\xe1R\xb7\x19 K\x0cY" +
-	"\xc2\xa8\x0b\xefw\xf1\x06\xc7\x9e\xdf\x88\xe7^\x08\xa2n" +
-	"\x93\xc7\x91\xb4\xb8Ed\x81H\xe4N\x11\xc9\x0c\x87," +
-	"0\x14\x03\x83\x84\x99\xb1\xe7\x04\xccLhb@\xbe\xbc" +
-	"\x10\xd4\xbbq\xa8<@Z<E4\xb2\x05\xc3\x1d\x10" +
-	"\xe2\x141\x91\xb2\x8bQ\xc7\xef\xb5k\xf00\x85\xe6." +
-	"\xf7U\xca\xc9O\x0c\\\xbe\xdb\xdc\x09wn\x0cwu" +
-	"p\x1bb\x1c%\x01b\xef\x91\xa38\xec\x8cF\xde\xd7" +
-	"\x17\xcfW~\x0b\xd1\xd4\x9c\xcaV\xfd!\xb3\xdc\xcaj" +
-	"\x9d0\xb9&\x9c\x1a\x87|\x8e!\x87\x7fu\x01\xe6\xdb" +
-	"gg\x89\xe43\x1c\xd2c\xc8\xb1\x7f40~\x85\xe2" +
-	"\xc29b\xf9v\xd8\x0e(m\xb7\xa2W\x86Q]5" +
-	"\xd9\xbbJ\xed\xcd\xef\xab~fv3\x9e\x82\xf3T1" +
-	"9\xf7\xf1L\x06\xc3\xcd\xc3\xf0\x11\x08i2pm`" +
-	"\xb4\xd0\x18>Aq\xbaDL\x9c\xb0\xc1Fo\x0f\xc3" +
-	"\x7f\x03q\xcc\xd4\x0e\xdb\xc5\x84\xa0\x86\xbcq\xb2\x86\xbc" +
-	"\xf1j\xd7$w8\xfe\x7f3wO\xdb\xf3\x95\xed\xb7" +
-	"\"\xb3\xf6\x83\xb0\x8f\x9f\x1fo\xb80k\x0f@T/" +
-	"\x12\xc9\x0a\x87|\x92A\xbf|%\x0e\x9e\x0e\x97\x02\"" +
-	"B\x8e\x18r\x04\x1d\xb4cu\xc5\x0b\x1b\xc4\xdb\xf1\xc0" +
-	"X\x12\x98\xb5U\xb7\xbd\xbf\xaf\x06\x93\xb7\xa2\xff\x02\x00" +
-	"\x00\xff\xff\xa8.}\xb7"
+const schema_9a51e53177277763 = "x\xda|\x92Oh\x13M\x18\xc6\xdfgf\xd3\x0d|" +
+	"\xc9W\xa6[\xab\xf6R\xac\x15\xb5\xd26\xb1\x1eT\x94" +
+	"\x06%\x14zq\xc7\x9b\x82\xd25.\x18h\x93\xb8\x7f" +
+	"H{\x10\xe9A\xc4\xa3\x8a\x88\x8aX\x0fR\x05\xd1R" +
+	"\xbdX\xf1\xe0\xa1x\x95\xa8\x14\xf4 (\x82\x08\x16\xf1" +
+	"\xe6ie6\xd95\xad\xa6\xb7\x19\xdew\x9e\xf7y\x7f" +
+	"\xf3dF\x90\xd3\xb2\xe9e\x8d\x98\xdc\x9bh\x0bv\x8d" +
+	"\xcf\xde\xc9{\xe3\xb7Iv\x01D\x9aN4,Y7" +
+	"\x08\xc616B\x08j\xfe\xcc\xbd\xc5\x93\x83\x8fI\xfc" +
+	"\xcf\x83Bu{5\xfbE\xde$\x82q\x8e-\x1a\x17" +
+	"\x98Nd\xcc\xb0Q\xe3\x81:\x05\xb7^\xd7\xe6\xe6\xbb" +
+	"\x8e<'\xb1\x11D\x09(\xb5\xcb\xac_\xa9\xdd\x08\xd5" +
+	"V\xae\xbfu\x17\xced\x97HtE\xd3\x9e\xa9iZ" +
+	"\xf0\xf5\xe2\xcb\xb6\x8f\xfeP\xad\xa9r\x97u\xa8\xca\xc3" +
+	"\xd1L\xdf\xec\xd3\xfe\xe5\xa6\xca%\xd6\xab*\xc3m\xdb" +
+	"\xee\xbf\xf9\xb1\xf5\xfd_\xde\xce\xb2\x05c:\xf4\xe6\xb3" +
+	"W\xc6\xf7\xd0\xdb\xe8\x89\xa1\xf9\xcd\x8f\xe6V\x9ad\xde" +
+	"\xd5\x07t\\\xbdr\xed\xdb\xc1\xff~6\\\xab\xee\xe1" +
+	"\x17j\x02\x8c%V%\x04\x9f\x9f|H~\x1a+\xfe" +
+	"jz:\xc0\xbbA\x99\xa0\xe2\x94\x0b\xb6\xeb\x0e\xf2\x82" +
+	"U)U\xf6\x9b\x8dk\xd5*z}Gm\xd7\x9f\xe0" +
+	"\x9e+5\xae\x11i \x12\xe91\"\x99\xe2\x90\x9b\x18" +
+	"\x02{\xaa\xe8\x1d.\x9f\xb6\x89\x08IbH\x12b=" +
+	"\xd4\xf5\xf2S#v\xc1\xf7\xca\x8e\x09H\x8d'\x88b" +
+	"\xb3\x88X\x0b\xb1\x9b\x98H\xe8=n\xc5\xaa\x96r0" +
+	"\x81\xb5\xb6\xf2Su\x95\xc1\xb0E\x19k\xf7'V\x1b" +
+	";D$\x93\x1c\xb2\x93\xe1|\xe35\xc4\x1f\xc0\x04\x08" +
+	"B\xabu]\xaf\\\x89\xd7]\x97\x89i9\xd6$\xdc" +
+	"\xd6B\x96S\x07\xa7O4)!\xea\xea\x09\xef\x0aF" +
+	"*\x84\x11}\x0c\xa2\x8c\x08\xa9`\xe4u \xfeoD" +
+	"\x99\x13\xfb\xfa\x89\x89\x01\x1d,\x0e\x1b\xa2\xf8\x8b-\xaa" +
+	"\xb6A\xef\x09\x1d\xe4\xd0\xaeV\xca\xa1]\x99\xfe'\xd2" +
+	"U\xab\xb7\xd8j\x0dv\xd3rtk\xd2\x95\xc9\x98\xfa" +
+	"N\x15\x87\x1d\x1cr\x0f\x83\x00:\x01@d\x8f\x13\xc9" +
+	"\x0c\x87<\xc0\x10\x9c\x9a\xf6\xec(#ibH\x13\x02" +
+	"\xbb\xe49\xd3f\xb9H\xbc\xe4!E\x0c)\"\x81^" +
+	"\xdd\xf1K\xebsU6\xf9\xa4\xfb;\x00\x00\xff\xff\xdc" +
+	"a-["
 
 func init() {
 	schemas.Register(schema_9a51e53177277763,
-		0x84fc61ad6ff505d7,
 		0x9d6074459fa0602b,
 		0xaf2e5ebaa58175d2,
 		0xbb4f16b0a7d2d09b,
 		0xc53168b273d497ee,
 		0xd22f75df06c187e8,
-		0xd6be5a33d8c2c538,
 		0xd72ab4a0243047ac,
 		0xda23f0d3a8250633,
 		0xeea7ae19b02f5d47,


### PR DESCRIPTION
Small cleanup following #100.  Removes deprecated `ExitError` schema.