### PR TITLE
Generate default wazero.RuntimeConfig from Fx.

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -52,6 +52,7 @@ func clientDefaults(opt []Option) []Option {
 func serverDefaults(opt []Option) []Option {
 	return append([]Option{
 		WithHostConfig(casm.Server),
+		WithWASMConfig(nil),
 	}, opt...)
 }
 

--- a/pkg/runtime/wasm.go
+++ b/pkg/runtime/wasm.go
@@ -1,0 +1,15 @@
+package runtime
+
+import (
+	"github.com/tetratelabs/wazero"
+	"go.uber.org/fx"
+)
+
+func (c Config) WASM() fx.Option {
+	if c.wasmConfig == nil {
+		return fx.Options()
+	}
+
+	rc := fx.Annotate(c.wasmConfig, fx.As(new(wazero.RuntimeConfig)))
+	return fx.Supply(rc)
+}


### PR DESCRIPTION
Creates a `wazero.RuntimeConfig` in Fx (`pkg/runtime`) that enables two features:

- Shared compilaton cache across all `wazero.Runtime` instances
- `WithCloseOnContextDone`

```go
// WithCloseOnContextDone ensures the executions of functions to be closed under one of the following circumstances:
//
// 	- context.Context passed to the Call method of api.Function is canceled during execution. (i.e. ctx by context.WithCancel)
// 	- context.Context passed to the Call method of api.Function reaches timeout during execution. (i.e. ctx by context.WithTimeout or context.WithDeadline)
// 	- Close or CloseWithExitCode of api.Module is explicitly called during execution.
//
// This is especially useful when one wants to run untrusted Wasm binaries since otherwise, any invocation of
// api.Function can potentially block the corresponding Goroutine forever. Moreover, it might block the
// entire underlying OS thread which runs the api.Function call. See "Why it's safe to execute runtime-generated
// machine codes against async Goroutine preemption" section in internal/engine/compiler/RATIONALE.md for detail.
//
// Note that this comes with a bit of extra cost when enabled. The reason is that internally this forces
// interpreter and compiler runtimes to insert the periodical checks on the conditions above. For that reason,
// this is disabled by default.
//
// See examples in context_done_example_test.go for the end-to-end demonstrations.
//
// When the invocations of api.Function are closed due to this, sys.ExitError is raised to the callers and
// the api.Module from which the functions are derived is made closed.
```