### PR TITLE
Add ww run command.  

### DIFF
--- a/cmd/ww/main.go
+++ b/cmd/ww/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/wetware/ww/internal/cmd/cluster"
 	"github.com/wetware/ww/internal/cmd/debug"
+	"github.com/wetware/ww/internal/cmd/run"
 	"github.com/wetware/ww/internal/cmd/start"
 	ww "github.com/wetware/ww/pkg"
 )
@@ -58,11 +59,12 @@ var flags = []cli.Flag{
 var commands = []*cli.Command{
 	start.Command(),
 	cluster.Command(),
+	run.Command(),
 	debug.Command(),
 }
 
 func main() {
-	run(&cli.App{
+	app := &cli.App{
 		Name:                 "wetware",
 		HelpName:             "ww",
 		Usage:                "simple, secure clusters",
@@ -75,10 +77,8 @@ func main() {
 		Metadata: map[string]interface{}{
 			"version": ww.Version,
 		},
-	})
-}
+	}
 
-func run(app *cli.App) {
 	if err := app.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -1,0 +1,79 @@
+package run
+
+import (
+	"crypto/rand"
+	"errors"
+	"io"
+	"os"
+
+	// "github.com/stealthrocket/wazergo"
+	"github.com/tetratelabs/wazero"
+	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
+	"github.com/urfave/cli/v2"
+	// "github.com/wetware/ww/pkg/csp/proc"
+)
+
+func Command() *cli.Command {
+	return &cli.Command{
+		Name:   "run",
+		Usage:  "execute a local webassembly process",
+		Before: setup(),
+		After:  teardown(),
+		Action: run(),
+	}
+}
+
+var (
+	r wazero.Runtime
+	// h *wazergo.ModuleInstance[*proc.Module]
+)
+
+func setup() cli.BeforeFunc {
+	return func(c *cli.Context) error {
+		r = wazero.NewRuntime(c.Context)
+		// h = proc.BindModule(c.Context, r)
+		wasi_snapshot_preview1.MustInstantiate(c.Context, r)
+		return nil
+	}
+}
+
+func teardown() cli.AfterFunc {
+	return func(c *cli.Context) error {
+		return r.Close(c.Context)
+	}
+}
+
+func run() cli.ActionFunc {
+	return func(c *cli.Context) error {
+		b, err := bytecode(c)
+		if err != nil {
+			return err
+		}
+
+		module, err := r.InstantiateWithConfig(c.Context, b, wazero.NewModuleConfig().
+			WithRandSource(rand.Reader).
+			WithStartFunctions(). // disable auto-calling of _start
+			WithStdout(c.App.Writer).
+			WithStderr(c.App.ErrWriter))
+		if err != nil {
+			return err
+		}
+
+		fn := module.ExportedFunction("_start")
+		if fn == nil {
+			return errors.New("ww: missing export: _start")
+		}
+
+		// _, err = fn.Call(wazergo.WithModuleInstance(c.Context, h))
+		_, err = fn.Call(c.Context)
+		return err
+	}
+}
+
+func bytecode(c *cli.Context) ([]byte, error) {
+	if c.Args().Len() > 0 {
+		return os.ReadFile(c.Args().First()) // file path
+	}
+
+	return io.ReadAll(c.App.Reader) // stdin
+}


### PR DESCRIPTION
This PR provides a command for executing WASM binaries locally.  It is part of the workstream to break #111 into smaller chunks.

Commented code will be uncommented in a follow-up commit that adds piecemeal support for the ww host module.

If you want to test this, try compiling the following with `tinygo -o main.wasm -target=wasi main.go`, and running it with `ww run main.wasm`.

```go
package main

import "fmt"

// main.go

func main() {
    fmt.Println("hello, wetware!")
}
```
