### PR TITLE
Drop support for Go v1.19.

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.19', '1.20' ]
+        go: [ '1.20' ]
     name: Go ${{ matrix.go }}
     steps:
       - name: Clone feature branch

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/wetware/ww
 
-go 1.19
+go 1.20
 
 require (
 	capnproto.org/go/capnp/v3 v3.0.0-alpha.27


### PR DESCRIPTION
https://github.com/wetware/ww/pull/111 requires unsafe.SliceData, which is not available before 1.20.  This PR updates the version number in go.mod and removes 1.19 from CI.

We could preserve backwards compatibility by using build tags and relying on the highly-unsafe runtime.SliceHeader, but given that we are still pre-1.0, I don't think it's worth the trouble.