### PR TITLE
`Add csp.Client function to send capabilities over a channel.

### DIFF
--- a/pkg/csp/chan.go
+++ b/pkg/csp/chan.go
@@ -216,6 +216,16 @@ func Ptr(ptr capnp.Ptr) Value {
 	}
 }
 
+// Client takes any client-like type and converts it into a value
+// capable of being sent through a channel.
+func Client[T ~capnp.ClientKind](t T) Value {
+	return func(ps api.Sender_send_Params) error {
+		id := ps.Message().CapTable().Add(capnp.Client(t))
+		ifc := capnp.NewInterface(ps.Segment(), id)
+		return ps.SetValue(ifc.ToPtr())
+	}
+}
+
 // Struct takes any capnp struct and converts it into a value
 // capable of being sent through a channel.
 func Struct[T ~capnp.StructKind](t T) Value {


### PR DESCRIPTION
Note that I haven't tested this yet.  @evan-schott If you're feeling lucky, feel free to merge.  Worst-case-scenario it doesn't work, in which case, just open an issue and we'll get it fixed.

To convert the pointer back into a client:  `ptr.Interface().Client()`.