### PR TITLE
Add host module for calling wetware capabilities from proc.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/ipfs/go-ds-badger2 v0.1.3
 	github.com/lthibault/go-libp2p-inproc-transport v0.4.0
 	github.com/multiformats/go-multistream v0.4.1
+	github.com/stealthrocket/wazergo v0.14.0
 	github.com/stretchr/testify v1.8.2
 	github.com/tetratelabs/wazero v1.0.1
 	github.com/thejerf/suture/v4 v4.0.2

--- a/go.sum
+++ b/go.sum
@@ -472,6 +472,8 @@ github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tL
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
+github.com/stealthrocket/wazergo v0.14.0 h1:QlqvyXyQkKeVNVU8gzPmTuBv1PA5h6u8etUi/gEE7zg=
+github.com/stealthrocket/wazergo v0.14.0/go.mod h1:ONoLQpwgBDX9VGB+CCAbzTNDmJJi5kcnFLL+pWIGF5M=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/cmd/run/run.go
+++ b/internal/cmd/run/run.go
@@ -6,11 +6,11 @@ import (
 	"io"
 	"os"
 
-	// "github.com/stealthrocket/wazergo"
+	"github.com/stealthrocket/wazergo"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/imports/wasi_snapshot_preview1"
 	"github.com/urfave/cli/v2"
-	// "github.com/wetware/ww/pkg/csp/proc"
+	"github.com/wetware/ww/pkg/csp/proc"
 )
 
 func Command() *cli.Command {
@@ -25,13 +25,13 @@ func Command() *cli.Command {
 
 var (
 	r wazero.Runtime
-	// h *wazergo.ModuleInstance[*proc.Module]
+	h *wazergo.ModuleInstance[*proc.Module]
 )
 
 func setup() cli.BeforeFunc {
 	return func(c *cli.Context) error {
 		r = wazero.NewRuntime(c.Context)
-		// h = proc.BindModule(c.Context, r)
+		h = proc.BindModule(c.Context, r)
 		wasi_snapshot_preview1.MustInstantiate(c.Context, r)
 		return nil
 	}
@@ -64,8 +64,7 @@ func run() cli.ActionFunc {
 			return errors.New("ww: missing export: _start")
 		}
 
-		// _, err = fn.Call(wazergo.WithModuleInstance(c.Context, h))
-		_, err = fn.Call(c.Context)
+		_, err = fn.Call(wazergo.WithModuleInstance(c.Context, h))
 		return err
 	}
 }

--- a/pkg/csp/executor.go
+++ b/pkg/csp/executor.go
@@ -7,11 +7,13 @@ import (
 	"errors"
 
 	capnp "capnproto.org/go/capnp/v3"
+	"github.com/stealthrocket/wazergo"
 	"github.com/tetratelabs/wazero"
 	"lukechampine.com/blake3"
 
 	wasm "github.com/tetratelabs/wazero/api"
 	api "github.com/wetware/ww/internal/api/process"
+	"github.com/wetware/ww/pkg/csp/proc"
 )
 
 // ByteCode is a representation of arbitrary executable data.
@@ -49,7 +51,8 @@ func (ex Executor) Exec(ctx context.Context, src []byte) (Proc, capnp.ReleaseFun
 // Runtime is the main Executor implementation.  It spawns WebAssembly-
 // based processes.  The zero-value Runtime panics.
 type Runtime struct {
-	Runtime wazero.Runtime
+	Runtime    wazero.Runtime
+	HostModule *wazergo.ModuleInstance[*proc.Module]
 }
 
 // Executor provides the Executor capability.
@@ -124,8 +127,7 @@ func (r Runtime) spawn(fn wasm.Function) (<-chan execResult, context.CancelFunc)
 		defer close(out)
 		defer cancel()
 
-		// vs, err := fn.Call(wazergo.WithModuleInstance(ctx, r.HostModule))
-		vs, err := fn.Call(ctx)
+		vs, err := fn.Call(wazergo.WithModuleInstance(ctx, r.HostModule))
 		out <- execResult{
 			Values: vs,
 			Err:    err,

--- a/pkg/csp/proc/proc.go
+++ b/pkg/csp/proc/proc.go
@@ -1,0 +1,132 @@
+// Package proc provides the WebAssembly host module for Wetware processes
+package proc
+
+import (
+	"context"
+	"io"
+	"net"
+
+	"capnproto.org/go/capnp/v3"
+	"capnproto.org/go/capnp/v3/exp/bufferpool"
+	"capnproto.org/go/capnp/v3/rpc"
+	"github.com/lthibault/log"
+	"github.com/stealthrocket/wazergo"
+	. "github.com/stealthrocket/wazergo/types"
+	wasm "github.com/tetratelabs/wazero"
+)
+
+var fs wazergo.HostModule[*Module] = functions{
+	"__host_write": wazergo.F2((*Module).Write),
+	"__host_read":  wazergo.F2((*Module).Read),
+	"__host_close": wazergo.F0((*Module).ClosePipe),
+}
+
+// BindModule instantiates a host module instance and binds it to the supplied
+// runtime.  The returned module instance is bound to the lifetime of r.
+func BindModule(ctx context.Context, r wasm.Runtime, opt ...Option) *wazergo.ModuleInstance[*Module] {
+	// We use BindModule to avoid exporting fs as a public variable, since this
+	// would allow users to mutate it.
+	return wazergo.MustInstantiate(ctx, r, fs, opt...)
+}
+
+type functions wazergo.Functions[*Module]
+
+func (functions) Name() string {
+	return "ww"
+}
+
+func (f functions) Functions() wazergo.Functions[*Module] {
+	return (wazergo.Functions[*Module])(f)
+}
+
+func (f functions) Instantiate(ctx context.Context, opts ...Option) (*Module, error) {
+	module := &Module{}
+	wazergo.Configure(module, opts...)
+
+	var rwc io.ReadWriteCloser
+	rwc, module.pipe = net.Pipe()
+
+	module.conn = rpc.NewConn(rpc.NewStreamTransport(rwc), &rpc.Options{
+		BootstrapClient: module.bootstrap,
+		ErrorReporter:   module.errReporter(),
+	})
+
+	return module, nil
+}
+
+type Option = wazergo.Option[*Module]
+
+// WithClient sets the bootstrap client provided to the guest code.
+func WithClient[Client ~capnp.ClientKind](c Client) Option {
+	return wazergo.OptionFunc(func(m *Module) {
+		m.bootstrap = capnp.Client(c)
+	})
+}
+
+// WithLogger sets the error logger for the capnp transport.   If
+// l == nil, logging is disabled.
+func WithLogger(l log.Logger) Option {
+	if l == nil {
+		l = log.New(log.WithLevel(log.FatalLevel))
+	}
+
+	return wazergo.OptionFunc(func(m *Module) {
+		m.logger = l
+	})
+}
+
+type Module struct {
+	pipe io.ReadWriteCloser
+	conn io.Closer
+
+	logger    log.Logger
+	bootstrap capnp.Client
+}
+
+func (m Module) Close(context.Context) error {
+	return m.conn.Close() // close the host side of the connection
+}
+
+func (m Module) Write(ctx context.Context, b Bytes, n Pointer[Uint32]) Error {
+	// b is only valid until Write returns.
+	//
+	// TODO(perf):  can the guest somehow "pin" b to a global map, and
+	//              expect the transport to call free(b)?  This would
+	//              give us a truly zero-copy transport, though we would
+	//              likely have to operate at the Arena level for this.
+	p := bufferpool.Default.Get(len(b))
+	copy(p, b)
+
+	// Due to a bug in wazergo, we need to use Pointer[Uint32] to extract
+	// the number of bytes written.
+	//
+	// TODO:  revert to Optional[Uint32] when possible.
+	u, err := m.pipe.Write(p)
+	n.Store(Uint32(u))
+
+	return Err[None](err)
+}
+
+func (m Module) Read(ctx context.Context, b Bytes, n Pointer[Uint32]) Error {
+	u, err := m.pipe.Read(b)
+	n.Store(Uint32(u)) // See Write()
+	return Err[None](err)
+}
+
+func (m Module) ClosePipe(ctx context.Context) Error {
+	return Err[None](m.pipe.Close())
+}
+
+func (m Module) errReporter() errReporter {
+	return errReporter{
+		Logger: m.logger,
+	}
+}
+
+type errReporter struct {
+	log.Logger
+}
+
+func (er errReporter) ReportError(err error) {
+	er.Logger.Error(err)
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/wetware/casm/pkg/cluster/routing"
 	"github.com/wetware/casm/pkg/debug"
 	"github.com/wetware/ww/pkg/csp"
+	"github.com/wetware/ww/pkg/csp/proc"
 )
 
 type ClusterConfig struct {
@@ -80,8 +81,13 @@ func (rc RuntimeConfig) New() csp.Runtime {
 	r := wazero.NewRuntimeWithConfig(rc.Ctx, rc.Config)
 	wasi_snapshot_preview1.MustInstantiate(rc.Ctx, r)
 
+	m := proc.BindModule(rc.Ctx, r,
+		proc.WithLogger(rc.Logger),
+		/* proc.WithClient(capnp.Client{}) */)
+
 	return csp.Runtime{
-		Runtime: r,
+		Runtime:    r,
+		HostModule: m,
 	}
 }
 


### PR DESCRIPTION
Adds `ww` host module implementation and binds it to the WASM runtime.  A follow-up PR will introduce the guest library, which receives the bootstrap capability provided by the host module.