### PR TITLE
Add pubsub capability to embedded ww server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -40,6 +40,7 @@ type Cluster interface {
 type Node struct {
 	Vat casm.Vat
 	Cluster
+	host.PubSubProvider
 }
 
 func (n Node) Loggable() map[string]any {
@@ -65,17 +66,19 @@ func (j Joiner) Join(vat casm.Vat, r Router) (*Node, error) {
 		return nil, err
 	}
 
+	ps := j.pubsub(vat.Logger, r)
 	vat.Export(host.Capability, host.Server{
 		ViewProvider:     c,
-		PubSubProvider:   j.pubsub(vat.Logger, r),
+		PubSubProvider:   ps,
 		AnchorProvider:   j.anchor(),
 		DebugProvider:    j.Debugger.New(),
 		ExecutorProvider: j.Runtime.New(),
 	})
 
 	return &Node{
-		Vat:     vat,
-		Cluster: c,
+		Vat:            vat,
+		Cluster:        c,
+		PubSubProvider: ps,
 	}, nil
 }
 


### PR DESCRIPTION
This pull request adds the pubsub capability to the embedded WW server in order to enhance its functionality.

The main changes in this PR include:

1. The addition of the `PubSubProvider` field to the `Node` struct, which represents a pubsub provider for the server.
2. Modification of the `Join` method in the `Node` struct to initialize the pubsub provider using the `j.pubsub` function, passing the appropriate parameters.
3. In the `Join` method, the `PubSubProvider` field is assigned the value returned by the `j.pubsub` function.
4. In the `vat.Export` function call within the `Join` method, the `PubSubProvider` is included as part of the `host.Server` struct.

These changes enable the embedded WW server to support pubsub functionality, allowing for efficient communication and message distribution between connected clients.