### PR TITLE
Add basic tracing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 tracing::info!("got PING event: {event:?}");
             }
             event => {
-                tracing::info!("got PONG event: {event:?}");
+                tracing::info!("got event: {event:?}");
             }
         }
     }

--- a/src/net.rs
+++ b/src/net.rs
@@ -1,0 +1,31 @@
+use libp2p::{
+    mdns, ping,
+    swarm::NetworkBehaviour,
+};
+
+#[derive(NetworkBehaviour)]
+#[behaviour(to_swarm = "DefaultBehaviourEvent")]
+pub struct DefaultBehaviour {
+    pub mdns: mdns::tokio::Behaviour,
+    pub ping: ping::Behaviour,
+}
+
+#[derive(Debug)]
+pub enum DefaultBehaviourEvent {
+    // Events emitted by the MDNS behaviour.
+    Mdns(mdns::Event),
+    // Events emitted by the Ping behaviour.
+    Ping(ping::Event),
+}
+
+impl From<mdns::Event> for DefaultBehaviourEvent {
+    fn from(event: mdns::Event) -> Self {
+        DefaultBehaviourEvent::Mdns(event)
+    }
+}
+
+impl From<ping::Event> for DefaultBehaviourEvent {
+    fn from(event: ping::Event) -> Self {
+        DefaultBehaviourEvent::Ping(event)
+    }
+}


### PR DESCRIPTION
This sets up basic tracing in `main.rs`.  It configures a global tracer with a few niceties:  terminal colors, log levels & human-oriented formatting.

We should probably upgrade to structured logic in the near future.