### PR TITLE
docs: harden post-Glia current-state guidance

### DIFF
--- a/.agents/skills/ww-build-app.md
+++ b/.agents/skills/ww-build-app.md
@@ -29,13 +29,14 @@ Work through these questions *conversationally* — don't present
 them as a checklist.  Weave them into the discussion as they
 become relevant.  One at a time.
 
-- **What cell type fits?**  This is the first architectural decision.
+- **What service transport fits?**  This is the first network decision.
   Explain the options briefly and help them choose:
-  - `raw` — custom binary protocols, file transfer, tunneling
-  - `http` — REST APIs, web services, familiar tooling
-  - `capnp` — typed capabilities, schema-addressed discovery,
-    bidirectional RPC
-  - pid0 — the agent IS the kernel (rare, advanced)
+  - byte stream — custom binary protocols through `StreamListener.listen()`
+  - HTTP/WAGI — HTTP routes through `HttpListener.listen()`
+  - Cap'n Proto vat — typed capabilities published through
+    `VatListener.serveAuthenticated()` or the explicit raw escape hatch
+  - no network publication — an ordinary child used only through delegated
+    capabilities
 
   If they're unsure: "What does your app's network interface look
   like?  HTTP endpoints?  Binary streams?  Typed RPC?"
@@ -62,14 +63,13 @@ When you have enough to sketch an architecture, say so:
 
 Based on discovery, produce a concrete design.  Cover:
 
-- **Cell type and protocol**: confirm the type.  For `capnp`
-  cells, sketch the `.capnp` interface.  For `http`, define
-  endpoints.  For `raw`, define the wire format.
+- **Service transport and protocol**: confirm the registration or publication
+  API. For Cap'n Proto vats, sketch the `.capnp` interface. For HTTP, define
+  endpoints. For byte streams, define the wire format.
 - **Image layout**: what goes in `bin/`, `svc/`, `etc/`.
   Reference `doc/images.md`.
-- **Build pipeline**: source → WASM component → `schema-inject`
-  (if non-pid0).  Reference `examples/counter/Makefile` as
-  template.
+- **Build pipeline**: source → WASI P2 component. Reference
+  `examples/counter/Makefile` as a Rust template.
 - **Capability map**: which capabilities each agent needs.  Flag
   anything that could be attenuated.  Reference `doc/capabilities.md`.
 - **Membrane design**: what pid0 exports, what children receive.
@@ -78,8 +78,8 @@ Based on discovery, produce a concrete design.  Cover:
 
 Present the architecture as a structured outline or diagram.
 
-⚗️ Milestone: "Design phase done — we've mapped out agents, cell
-types, capabilities, and coordination."  Then ask:
+⚗️ Milestone: "Design phase done — we've mapped out agents, transports,
+capabilities, and coordination."  Then ask:
 
 > Does this match what you had in mind?  Anything to change before
 > we write it up?
@@ -91,10 +91,10 @@ Get sign-off before moving to the handoff.
 Produce a design document another human (or AI) can execute from:
 
 - System diagram showing agents, capabilities, and data flow
-- Cell type for each agent
+- Service transport and registration API for each agent
 - Capability map: per-agent capabilities and attenuations
 - Image layout: directory tree
-- Build pipeline: compile + inject steps
+- Build pipeline: component compilation steps
 - Protocol specs: interface sketches, endpoints, or wire format
 - Open questions and risks
 

--- a/.agents/skills/ww-concepts.md
+++ b/.agents/skills/ww-concepts.md
@@ -41,30 +41,27 @@ Wetware addresses it.  One concept at a time.
 
 ### Cells
 
-Key files: `capnp/cell.capnp`, `doc/architecture.md` section
-"Cell types"
+Key files: `doc/architecture.md`, `doc/api/wasm-guest.md`, and
+`capnp/system.capnp`
 
-A Cell is a WASM binary with a type tag stored in a **WASM custom
-section** named `"cell.capnp"`.  The tag is a Cap'n Proto union
-injected post-build by `schema-inject` — the WASM itself doesn't
-know about it.  When the host loads a Cell, it reads the custom
-section to decide what plumbing to wire up (network listeners,
-protocol bridges, etc.).  No section = pid0.
+A Cell is a WASI P2 component that runs in the WASM sandbox.
+Transport is selected when a capability holder registers or publishes a
+service. The host does not infer transport from a WASM custom section.
 
-Read `capnp/cell.capnp` and show the actual schema.  Then walk
-through the four variants **one at a time**, checking in between
-each:
+Walk through the current transport choices one at a time:
 
-1. **`raw`** — raw libp2p stream bytes.  Think: custom binary
-   protocols.  "Make sense?  Next one's more familiar."
-2. **`http`** — FastCGI.  Think: REST APIs with familiar tooling.
-3. **`capnp`** — Cap'n Proto RPC.  Think: typed, schema-addressed
-   capabilities.
-4. **absent** — pid0 mode.  The kernel itself.  "This one's rare —
-   it's only for when you ARE the kernel."
+1. **Byte stream** — `StreamListener.listen()` spawns one process per
+   `/ww/0.1.0/stream/{protocol}` connection and wires stdin/stdout.
+2. **HTTP/WAGI** — `HttpListener.listen()` spawns one process per request and
+   uses CGI environment variables plus stdin/stdout.
+3. **Cap'n Proto vat** — a process exports a capability with
+   `system::serve()`. A publisher passes that capability to
+   `VatListener.serveRaw()` or `VatListener.serveAuthenticated()`.
+4. **PID0** — the Host starts the trusted kernel with the process-local
+   `Membrane` bootstrap.
 
-Emphasize: the cell type determines how a process talks to the
-*network*, not what it can do internally.
+Emphasize: transport registration determines network exposure. Explicit
+capability grants determine what the process can do.
 
 ### Capabilities (ambient authority problem)
 
@@ -85,13 +82,13 @@ Present one row at a time, explain each, check in.
 | process | Cell | Cell = WASM binary in a sandbox.  No ambient env, no fs, no sockets.  A process can do anything the OS allows; a Cell can only do what its capabilities permit. |
 | fork/exec | `runtime.load(wasm)` → `executor.spawn()` | Parent explicitly passes capabilities to child.  No inheritance of open fds, env vars, or fs access — you grant exactly what the child needs. |
 | file descriptor | Cap'n Proto client | Both are opaque handles.  But Unix fds live in a global namespace (paths) — any process can `open("/etc/passwd")`.  A capnp client is unforgeable and can only be obtained by explicit handoff. |
-| syscall table | Membrane → `graft()` | Both are the interface to kernel services.  But the syscall table is fixed and ambient — every process gets all of them.  `graft()` returns *only* the capabilities you were granted, and they can differ per Cell. |
-| `ioctl(fd, ...)` | method call on cap | Both operate on a handle.  But capnp calls are typed, async, and pipelined — not a bag-of-bytes command code.  `runtime.load(...).executor()` resolves in one round-trip via pipelining. |
+| syscall table | Membrane → `graft()` | Both are the interface to kernel services. The syscall table is fixed and ambient. `graft()` returns a `List(Export)` of named capability references. Only trusted PID0 receives the graft-capable `Membrane`. |
+| `ioctl(fd, ...)` | method call on cap | Both operate on a handle. Cap'n Proto calls are typed, async, and pipelined. A caller can pipeline `Executor.spawn()` on the result of `Runtime.load(wasm)`. |
 | filesystem | WASI VFS over IPFS + `$WW_ROOT` | No writable local fs in the sandbox.  Content is read through the WASI virtual filesystem — `open("$WW_ROOT/bin/foo.wasm")` transparently resolves `/ipfs/<cid>/...` paths.  Content-addressed, not capability-gated. |
-| `open()` returns fd | `graft()` returns Session | `open()` grants access to anything the path resolves to.  `graft()` returns a Session with specific named capabilities: Host, Executor, Routing, Identity — each of which can be null (withheld). |
+| `open()` returns fd | `graft()` returns `List(Export)` | `open()` grants access to anything the path resolves to. `graft()` returns named references such as `identity`, `host`, `runtime`, `routing`, `authority`, and `ipfs`; `http-client` is conditional. Omitted exports are absent, not null. |
 | signals | epoch lifecycle | Unix signals are fire-and-forget. An epoch advance makes host-issued capabilities stale. The Host terminates the old PID0 and starts a fresh PID0 for the new generation. |
 | pipe | `ByteStream` (`capnp/system.capnp`) | Both connect two processes via read/write.  But ByteStream is a capability — it can be passed to third parties, attenuated, or revoked. |
-| `bind()`/`listen()` | `StreamListener.listen()` / `VatListener.listen()` | Unix: any process can bind any port.  Wetware: listening requires the StreamListener or VatListener capability, scoped to a specific protocol.  No ambient network access. |
+| `bind()`/`listen()` | `StreamListener.listen()` / `VatListener.serveAuthenticated()` | Unix: any process can bind any port. Wetware requires an explicit listener capability. Vat publication serves an existing capability and does not spawn a process. |
 | semaphore / mutex | E-ordering (capnp objects) | No explicit locks.  Each capnp object serializes its own method calls — the object IS the lock.  Cross-object calls are concurrent; use pipelining to express ordering. |
 | ring 0 / ring 3 boundary | Membrane | The Membrane is the ring transition.  In x86 the `syscall` instruction crosses from ring 3 to ring 0.  In Wetware, `graft()` crosses from Cell to host.  The Membrane controls what's on the other side — like the IDT controls which kernel handlers userspace can invoke. |
 | init (pid 1) | pid0 (kernel Cell) | Both are the first process that sets up everything else.  pid0 receives the Membrane, decides policy, spawns children with attenuated caps.  The kernel IS a Cell. |
@@ -130,7 +127,7 @@ Then show what capnp adds on top:
    child.  Same interface, fewer methods.
 3. **Async pipelining.**  Every fd `read()`/`write()` is a
    blocking round-trip.  Capnp lets you chain calls on promises:
-   `runtime.load(cid).executor().spawn()` — one round-trip, not three.
+   pipeline `Executor.spawn()` on the result of `Runtime.load(wasm)`.
 4. **Network-transparent.**  A capnp client can point at a local
    object or a remote peer.  Same API, same types.  Passing an
    fd across machines requires bespoke plumbing.
@@ -179,9 +176,9 @@ is the object boundary.
 
 **Pipelining** is the key trick: instead of waiting for a result
 before making the next call, you can chain calls on *promises*.
-`runtime.load(cid).executor().spawn()` resolves in a single
-round-trip, not three.  This lets you express ordering constraints
-declaratively rather than with locks.
+Pipelining `Executor.spawn()` on `Runtime.load(wasm)` avoids waiting for the
+load response before sending the spawn call. This expresses ordering without
+an intermediate blocking wait.
 
 If the user has blockchain background: "This is like how each
 smart contract serializes its own state transitions, but without

--- a/.agents/skills/ww-examples.md
+++ b/.agents/skills/ww-examples.md
@@ -17,14 +17,14 @@ practice.
 
 Don't just present a list — ask what they're after:
 
-> We have three examples that show different cell types.  What
+> We have three examples that show different guest transports. What
 > sounds most useful to you?
 >
-> 1. **Echo** — simplest possible cell.  Good if you want to see
+> 1. **Echo** — simplest possible guest. Good if you want to see
 >    the bare minimum.  *(~5 min walkthrough)*
-> 2. **Counter** — WAGI cell with FastCGI.  Good if you're building
+> 2. **Counter** — WAGI guest with FastCGI. Good if you're building
 >    a web service.  *(~10 min walkthrough)*
-> 3. **Chess** — full Cap'n Proto vat cell over libp2p.  Good if you want
+> 3. **Chess** — Cap'n Proto vat guest over libp2p. Good if you want
 >    to see a real multi-node app.  *(~15 min walkthrough)*
 >
 > Or tell me what you're trying to build and I'll pick the most
@@ -32,7 +32,7 @@ Don't just present a list — ask what they're after:
 
 ---
 
-## 1. Echo (raw cell) — ~5 min
+## 1. Echo (stdin/stdout guest) — ~5 min
 
 Read files from `examples/echo/`.
 
@@ -45,10 +45,10 @@ Read files from `examples/echo/`.
 Walk through together:
 
 1. **What it does**: reads stdin, writes it back to stdout.  That's it.
-2. **Why it matters**: this is the stdin/stdout convention that *all*
-   cell types share.  Everything else builds on this.
+2. **Why it matters**: `StreamListener.listen()` wires each connection to a
+   guest through stdin/stdout.
 3. **Build it**: run `make -C examples/echo` yourself and show the
-   output.  No schema needed (raw cell, no typed RPC).
+   output. No schema is needed for this byte protocol.
 4. **See it tested**: `examples/echo_handler_e2e.rs` shows how the
    host spawns and exercises it.
 
@@ -63,7 +63,7 @@ with more moving parts?"
 
 ---
 
-## 2. Counter (HTTP/FastCGI cell) — ~10 min
+## 2. Counter (HTTP/FastCGI guest) — ~10 min
 
 Read files from `examples/counter/`.
 
@@ -77,25 +77,25 @@ Walk through together:
 
 1. **What it does**: serves `GET /counter` (returns count) and
    `POST /counter` (increments).  405 for everything else.
-2. **The key difference**: this cell has a *type tag*.  Run
-   `make -C examples/counter` yourself and show the output.
-   The repository does not currently ship a runtime composition for the
+2. **The key difference**: this guest speaks FastCGI over stdin/stdout. Run
+   `make -C examples/counter` yourself and show the output. The repository
+   does not currently ship an `HttpListener.listen()` composition for the
    counter.
 3. **FastCGI protocol**: the cell speaks binary FastCGI over stdio.
    The host translates HTTP ↔ FastCGI.  Simpler than parsing HTTP/1.1.
 4. **Per-request spawn**: each request gets a fresh instance.  Counter
    resets — that's expected for the demo.
 
-⚗️ **Name the win**: "You've seen the full build pipeline: compile
-WASM, inject cell type, host routes traffic.  That's how WAGI cells
-work."
+⚗️ **Name the win**: "You've seen the guest side of WAGI: compile a WASI P2
+component that speaks FastCGI. An `HttpListener.listen()` registration supplies
+the route and per-request process plumbing."
 
 Check in: "Ready for the big one (Chess), or want to dig into
 something here first?"
 
 ---
 
-## 3. Chess (Cap'n Proto vat cell) — ~15 min
+## 3. Chess (Cap'n Proto vat guest) — ~15 min
 
 Read files from `examples/chess/`.
 
@@ -114,9 +114,9 @@ everything at once:
    "This shows what a real multi-node Wetware app looks like."
 2. **The schema** (~3 min): Read `chess.capnp`.  Show the interface.
    "This is the contract between the two nodes."
-3. **The code** (~5 min): Walk through `src/lib.rs`.  Focus on: how
-   it registers a listener, accepts connections, manages game state.
-   Don't read every line — hit the interesting parts.
+3. **The code** (~5 min): Walk through `src/lib.rs`. Focus on how the guest
+   exports its service capability with `system::serve()` and manages game
+   state. Use the authority proof to show separate authenticated publication.
 4. **The image layout** (~2 min): show the built component under `bin/`.
 
 5. **Local computation vs. granted authority** (~3 min): Walk through

--- a/.agents/skills/ww-quickstart.md
+++ b/.agents/skills/ww-quickstart.md
@@ -45,8 +45,9 @@ The response reports `status: "ok"` and a non-null `peer_id`.
 
 1. Started a **libp2p swarm** on the configured port
 2. Loaded embedded `std/kernel/bin/main.wasm` — the Rust kernel Cell (pid0)
-3. Spawned it with a **Membrane** — the capability hub that grants
-   Host, Executor, IPFS, Routing, and Identity via Cap'n Proto RPC
+3. Spawned it with a **Membrane** whose `graft()` returns a `List(Export)`.
+   Canonical exports are `identity`, `host`, `runtime`, `routing`,
+   `authority`, and `ipfs`; `http-client` appears when configured.
 
 The kernel grafted onto the Membrane, received epoch-scoped
 capabilities, and installed the `/status` cell with an explicit `host` grant.

--- a/.agents/skills/ww-reference.md
+++ b/.agents/skills/ww-reference.md
@@ -26,7 +26,8 @@ If they want to browse, show the menu:
 
 > Pick a topic, or tell me what you're trying to do:
 >
-> 1. **Cell types** — raw, http, capnp, pid0 (`capnp/cell.capnp`)
+> 1. **Guest and service transports** — host bootstrap, byte streams, HTTP,
+>    and Cap'n Proto vats (`doc/api/wasm-guest.md`, `capnp/system.capnp`)
 > 2. **System capabilities** — Host, Executor, Process, streams
 >    (`capnp/system.capnp`)
 > 3. **Membrane & auth** — Terminal, Membrane, Epoch, Identity
@@ -35,17 +36,15 @@ If they want to browse, show the menu:
 >    (`capnp/routing.capnp`, `doc/routing.md`)
 > 5. **CLI** — flags, subcommands, env vars (`doc/cli.md`)
 > 6. **RPC transport** — duplex streams, scheduling (`doc/rpc-transport.md`)
-> 7. **schema-inject** — post-build cell type injection
->    (`crates/schema-id/src/bin/schema-inject.rs`)
-> 8. **Signing & keys** — Signer interface, key derivation
+> 7. **Signing & keys** — Signer interface, key derivation
 >     (`doc/keys.md`)
-> 9. **Cross-crate schemas** — sharing Cap'n Proto definitions
+> 8. **Cross-crate schemas** — sharing Cap'n Proto definitions
 >     across crates (`doc/capnp-cross-crate.md`)
-> 10. **Guest API** — WASI bindings for guest WASM modules
+> 9. **Guest API** — WASI bindings for guest WASM modules
 >     (`doc/api/wasm-guest.md`)
-> 11. **Guest runtime** — poll loop, Cap'n Proto RPC, and WASI
+> 10. **Guest runtime** — poll loop, Cap'n Proto RPC, and WASI
 >     integration (`doc/guest-runtime.md`)
-> 12. **Design docs** — historical and current design records
+> 11. **Design docs** — historical and current design records
 >     (`doc/designs/`; check each document's status header)
 
 ## How to present reference material
@@ -55,17 +54,10 @@ When walking through a `.capnp` file:
 - Then show the schema definition
 - One interface at a time — don't dump the whole file
 
-For `schema-inject`, run `cargo run -p schema-id --bin schema-inject -- --help`
-yourself and show the user the actual CLI output.  Then walk through
-the three modes with examples:
-- `--raw bitswap` — raw libp2p streams
-- `--http /api/v1` — HTTP/FastCGI routing
-- `--capnp schema.bytes [--no-ipfs]` — typed Cap'n Proto RPC
-
-Note: `--no-ipfs` (capnp only) skips pushing canonical schema bytes
-to IPFS via Kubo.  Useful offline or when Kubo isn't running.
-Protocol IDs for raw cells must not contain `/` (host prefixes
-`/ww/0.1.0/stream/` automatically).
+For service transports, show the relevant `capnp/system.capnp` method. Explain
+that the registration or publication call selects the transport. The host does
+not read a custom section to select one. Protocol names must not contain `/`;
+the host adds `/ww/0.1.0/stream/` or `/ww/0.1.0/vat/`.
 
 ## After each topic
 

--- a/.agents/skills/ww-review-app.md
+++ b/.agents/skills/ww-review-app.md
@@ -26,7 +26,7 @@ rest.
 
 If they want a full sweep, tell them what to expect:
 
-> I'll check seven things: cell type correctness, least authority,
+> I'll check seven things: transport registration, least authority,
 > trust boundaries, image layout, protocol correctness, boundary
 > I/O, and epoch safety.  I'll flag anything I find as
 > critical / warning / suggestion.  Should take a few minutes.
@@ -37,15 +37,15 @@ Work through these in order of impact.  **Report findings as you
 go** — don't save everything for the end.  Each finding is a small
 deliverable that keeps the review feeling productive.
 
-### 1. Cell type correctness
+### 1. Transport registration
 
-- Right custom section for the use case?
-- Cell type appropriate? (`raw` for streams, `http` for REST,
-  `capnp` for typed RPC, absent for pid0)
-- For `capnp`: embedded schema matches actual interface?
-- For `http`: path prefix matches host routing?
-- For `raw`: protocol ID valid (non-empty, no `/`)?
-- `schema-inject` idempotent in build pipeline?
+- Does the application use `StreamListener.listen()`, `HttpListener.listen()`,
+  `VatListener.serveRaw()`, or `VatListener.serveAuthenticated()` for the
+  intended service?
+- For a vat, does the published capability match the schema?
+- For HTTP, does the path prefix match host routing?
+- For stream or vat protocols, is the name non-empty and free of `/`?
+- Does the application keep service publication separate from process spawn?
 
 ### 2. Principle of least authority
 
@@ -103,8 +103,8 @@ After each area, share what you found.  Then compile a summary:
 1. **Summary** — overall assessment (1-2 sentences)
 2. **Findings** — numbered, each with severity
    (critical / warning / suggestion) and a concrete fix
-3. **Cell type audit** — confirm type is appropriate and correctly
-   injected
+3. **Transport audit** — confirm the registration or publication API matches
+   the intended protocol
 4. **Capability map** — table: current capabilities vs. recommended
    minimum
 

--- a/doc/ai-context.md
+++ b/doc/ai-context.md
@@ -34,7 +34,8 @@ Architecture (three layers):
   `CidTree` root, and owns PID0 replacement across epochs.
 - **Kernel** (`std/kernel`): calls `membrane.graft()` once, loads
   `$WW_ROOT/bin/status.wasm`, grants `host`, installs `/status`, calls
-  `kernel_ready()`, and remains alive until Host termination.
+  `kernel_ready()`, and normally remains alive until Host termination.
+  Interactive `WW_TTY` execution can also end on stdin EOF.
 - **Ordinary children**: spawned with an immutable `InitialAuthorityRecord`
   delivered by `InitialGrants`; they do not receive `Membrane.graft()`.
 

--- a/doc/api/wasm-guest.md
+++ b/doc/api/wasm-guest.md
@@ -124,7 +124,7 @@ kernel. It is deliberately absent from ordinary-cell linkers.
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `kernel-ready` (`kernel_ready()` in generated Rust) | `() -> result<_, stale-generation>` | Commit the generation bound by PID0's process-local graft. The guest supplies no generation or token. |
+| `kernel-ready` (`kernel_ready()` in generated Rust) | `() -> result<_, ready-error>` | Commit the generation bound by PID0's process-local graft. `ready-error` currently contains `stale-generation`. The guest supplies no generation or token. |
 
 This host function is not a Cap'n Proto capability. It cannot appear in a
 `Membrane` graft or `InitialGrants`, be delegated to a child, or cross a
@@ -151,33 +151,43 @@ it bootstraps a Cap'n Proto RPC session over them. The host serves the full
 
 ### Guest Entry Points
 
-The `system` crate (`std/system`) provides two entry points that handle
-all connection setup automatically:
+The `system` crate (`std/system`) provides these entry points, which handle
+connection setup automatically:
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
 | `system::run` | `(f: FnOnce(C) -> Future) -> ()` | Bootstrap host cap, run closure, drive RPC. |
+| `system::run_with` | `(poll_set: PollSet, f: FnOnce(C) -> Future) -> ()` | Run as `system::run` does, with additional guest pollables serviced alongside RPC. |
 | `system::serve` | `(bootstrap: Client, f: FnOnce(C) -> Future) -> ()` | Same as `run`, but also exports `bootstrap` to host. |
 | `system::serve_stdio` | `(bootstrap: Client) -> ()` | Export cap over stdin/stdout (no host bootstrap). For byte-stream handlers. |
 
-### Child Initial Grants
+### Graft Exports and Child Initial Grants
 
-An ordinary child calls `initial_grants.get()` to obtain exactly the immutable
-named capabilities delegated at spawn:
+`Membrane.graft()` returns a `List(Export)`. The current host graft uses the
+following canonical names. `identity` requires a configured signing key, and
+`http-client` appears only when the operator configures an `--http-dial`
+allowlist. Trusted PID0 can delegate any selected references to an ordinary
+child through `Executor.spawn` or a listener's registration-time grant list.
 
-| Capability | Interface | Description |
-|------------|-----------|-------------|
-| Host | `system_capnp::host` | Node identity, network interfaces. |
-| Runtime | `system_capnp::runtime` | Load WASM binaries and obtain Executors. |
-| Routing | `routing_capnp::routing` | DHT operations (provide/find_providers). |
-| Identity | `auth_capnp::identity` | Host-side signing, only when explicitly delegated. |
+| Export name | Interface | Description |
+|-------------|-----------|-------------|
+| `identity` | `auth_capnp::identity` | Host-side signing. |
+| `host` | `system_capnp::host` | Node identity and network interfaces. |
+| `runtime` | `system_capnp::runtime` | Load WASM binaries and obtain Executors. |
+| `routing` | `routing_capnp::routing` | DHT operations such as providing and finding providers. |
+| `authority` | `auth_capnp::authority` | Construct a policy-bound `Terminal` over an explicit capability. |
+| `ipfs` | `system_capnp::ipfs` | Read `/ipfs`, `/ipns`, or `/ipld` content through a `ByteStream`. |
+| `http-client` | `http_capnp::http_client` | Make outbound HTTP requests to the configured host allowlist. |
 
-IPFS content is not an RPC capability. If the host explicitly installs the
-known-CID cache substrate, guests may read `/ipfs/<cid>/...` for CIDs they
-already know. Without that execution-context wiring the path does not
-materialize. The substrate provides no enumeration, mutation, pin management,
-publishing, routing, dialing, or ambient network API, though reads can consume
-node network, disk, cache, and eviction resources.
+An ordinary child calls `InitialGrants.get()` to obtain exactly the immutable
+named references selected by its parent. `InitialGrants` does not add the
+canonical graft exports automatically.
+
+WASI filesystem access and the `ipfs` RPC capability are separate surfaces.
+When the host installs the content substrate, WASI guests can read IPFS-family
+paths through the virtual filesystem. The `ipfs` export provides
+`Ipfs.read(path)` for non-WASI clients and for explicit delegation. Neither
+surface provides enumeration, mutation, pin management, or publishing.
 
 Host-derived grants retain their **epoch guards** and become invalid when the
 host advances its epoch. Repeated `InitialGrants.get()` calls return the same
@@ -209,6 +219,7 @@ Full interface reference for the capabilities available to guests.
 | Method | Signature | Description |
 |--------|-----------|-------------|
 | `spawn` | `(args: List(Text), env: List(Text), caps: List(Export), fuelPolicy: FuelPolicy) -> (process: Process)` | Spawn a new instance of the bound WASM binary with args, env, explicit initial grants, and fuel policy. |
+| `cid` | `() -> (cid: Text)` | Return the CID of the WASM binary bound to this Executor. |
 
 ### Process
 
@@ -219,6 +230,7 @@ Full interface reference for the capabilities available to guests.
 | `stderr` | `() -> (stream: ByteStream)` | Readable stream from guest's stderr. |
 | `wait` | `() -> (exitCode: Int32)` | Block until process exits. |
 | `bootstrap` | `() -> (cap: Capability)` | Get the capability exported by the guest via `system::serve()`. |
+| `kill` | `() -> ()` | Terminate the process by revoking its fuel. |
 
 ### ByteStream
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -62,7 +62,8 @@ The Rust PID0 follows one straight-line sequence for each generation:
 2. Read `$WW_ROOT/bin/status.wasm`.
 3. Load the status component, grant `host`, and register `/status`.
 4. Call the private `kernel_ready()` import.
-5. Remain alive until the Host terminates the generation.
+5. Normally remain alive until the Host terminates the generation. With
+   `WW_TTY`, stdin EOF also ends PID0.
 
 PID0 does not poll for stale epochs and does not re-graft. The Host owns epoch
 awareness, PID0 termination, and PID0 replacement.
@@ -136,13 +137,18 @@ Host preparation does not activate.
 
 Route registrations are epoch-scoped and identity-owned. A stale registration
 stops dispatching immediately, and cleanup from an old registration cannot
-delete a fresh replacement. Route liveness is not a kernel-readiness signal.
+delete a fresh replacement. Route liveness does not change
+`KernelReadyGate`.
 
 Readiness has one commit event. After composition, trusted PID0 calls the
 argument-free private Component Model import
 `wetware:kernel-runtime/readiness@1.0.0` function `kernel-ready`. The host
 derives the generation from the process-local graft, rejects a stale
-generation, and commits `KernelReadyGate`; `/readyz` reads that gate directly.
+generation, and commits `KernelReadyGate`. Kernel readiness is this gate alone.
+Externally observed `/readyz` requires both kernel readiness and, when the HTTP
+route registry is configured, at least one live route. Without a route
+registry, the route condition is satisfied.
+
 The import is installed only on PID0's linker, is not a Cap'n Proto capability
 value, and therefore cannot be delegated to children or transferred over the
 network.

--- a/doc/capabilities.md
+++ b/doc/capabilities.md
@@ -85,7 +85,9 @@ Trusted pid0 receives the host capabilities below. An ordinary child receives
 only the named references its parent supplied in the `Executor.spawn` caps
 list or a listener's registration-time grant template. Each `Export` entry
 carries an inert name and a capability reference. The reference carries
-authority; the name does not resolve authority.
+authority; the name does not resolve authority. `identity` requires a
+configured signing key. `http-client` requires a non-empty `--http-dial`
+allowlist.
 
 | Capability | What it does |
 |------------|--------------|
@@ -94,6 +96,7 @@ authority; the name does not resolve authority.
 | **host** | Peer identity, listen addresses, connected peers, network access |
 | **runtime** | Load WASM binaries and obtain scoped Executors (with compilation caching) |
 | **routing** | Kademlia DHT: provide and find content/services |
+| **ipfs** | Read `/ipfs`, `/ipns`, or `/ipld` content through a `ByteStream` |
 | **http-client** | Outbound HTTP requests, gated by `--http-dial` allowlist |
 Application-specific entries use their parent-chosen grant-map keys.
 
@@ -107,7 +110,7 @@ re-graft. The Host terminates the old PID0 and starts a fresh PID0 for the new
 generation. Epoch guards do not revoke arbitrary capability
 references that were not issued by the host.
 
-### Content access (WASI path I/O only)
+### Filesystem content access
 
 Cells do not receive an explicit filesystem capability over the membrane.
 Filesystem substrate is fixed by the trusted execution context:
@@ -126,9 +129,10 @@ explicit `/ipfs/<cid>/...` paths. The WASI virtual filesystem and its reachable
 CID tree govern guest path I/O. The membrane governs RPC capability authority.
 
 Known-CID cache wiring is execution-context state, not a child-visible control
-capability. A child cannot replace or widen it, and it provides no
-CID enumeration, mutation, pin management, publishing, routing, arbitrary
-dialing, ambient network API, or `ipfs` RPC capability.
+capability. A child cannot replace or widen it. The separate `ipfs` graft
+export can be delegated explicitly and provides `Ipfs.read()` through a
+`ByteStream`; it does not expose cache controls, mutation, pin management,
+publishing, routing, or arbitrary dialing.
 
 This does not mean a CAS read has no node effect. A read can fetch over the
 node's network, pin and materialize blocks on disk, occupy cache budget, affect

--- a/doc/rpc-transport.md
+++ b/doc/rpc-transport.md
@@ -1,388 +1,223 @@
-# RPC Transport: Async Bidirectional Cap'n Proto over WASI Streams
+# RPC Transport: Host Channels and Network Services
 
-This document explains how the host and WASM agents communicate over
-Cap'n Proto RPC, with a focus on the transport plumbing, scheduling
-model, and deadlock analysis.
+Wetware uses Cap'n Proto RPC in two distinct places:
 
-Primary code references:
-- `src/rpc/mod.rs`
-- `src/cell/proc.rs`
-- `std/system/src/lib.rs`
+- Each WASM process has an in-memory host channel for its bootstrap and
+  delegated capabilities.
+- Published vat services run Cap'n Proto RPC over named libp2p streams.
 
-## High-level layout
+Raw byte-stream services also use named libp2p streams, but they do not add a
+Cap'n Proto vat unless the application implements one over stdin/stdout.
 
-At runtime there are two RPC links:
-- Host <-> pid0 (kernel agent)
-- Host <-> child (agent spawned by pid0 via `runtime.load()` + `executor.spawn()`)
+Primary implementation references:
 
-Both links use the same transport mechanism: Cap'n Proto RPC over a
-bidirectional in-memory duplex stream exposed to agents as WASI
-io/streams resources.
+- `crates/cell/src/proc.rs` — in-memory host/guest stream creation
+- `src/executor.rs` — trusted PID0 startup and host-side RPC driver
+- `src/launcher.rs` — ordinary-child startup and host-side RPC driver
+- `crates/rpc/src/graft.rs` — PID0 and ordinary-child bootstraps
+- `std/system/src/lib.rs` — guest-side RPC session and poll loop
+- `crates/rpc/src/vat_listener.rs` and `crates/rpc/src/vat_client.rs` — network vats
+- `crates/rpc/src/stream_listener.rs` and `crates/rpc/src/stream_dialer.rs` — byte streams
+- `capnp/membrane.capnp` and `capnp/system.capnp` — public capability interfaces
 
-```
-          (Cap'n Proto RPC over WASI io/streams)
-┌───────────────────────────┐           ┌───────────────────────────┐
-│        Host (ww)          │           │        pid0 (kernel)      │
-│  - serves Membrane        │<=========>│  - grafts, obtains Session │
-│  - VatNetwork + RpcSystem │           │  - poll_loop event loop    │
-└───────────────────────────┘           └───────────────────────────┘
-           ^                                            |
-           | runtime.load + spawn (child)               | Cap'n Proto RPC
-           |                                            v
-┌───────────────────────────┐           ┌───────────────────────────┐
-│        Host (ww)          │           │        child agent         │
-│  - serves Session         │<=========>│  - poll_loop event loop    │
-│  - VatNetwork + RpcSystem │           │                            │
-└───────────────────────────┘           └───────────────────────────┘
-```
+## Process-local host channel
 
-## Design rationale
+Every PID0 or ordinary-child process starts with a bidirectional in-memory
+stream created by `cell::proc::Builder::with_data_streams()`. The host retains
+one end. The guest receives the other end through
+`wetware:streams/streams@0.1.0`.
 
-The transport was migrated from a custom `wetware:streams` interface
-with stub pollables and a busy-spin loop to standard WASI `io/streams`
-+ `io/poll`. This eliminates CPU busy-spins in idle agents and aligns
-with the WASI component model.
-
-The transport uses **in-memory pipes** (`tokio::io::duplex`) with
-Wasmtime's `AsyncReadStream` / `AsyncWriteStream` adapters. No OS
-socket I/O is involved — all RPC messages traverse memory-only duplex
-streams.
-
-## Transport plumbing: host side
-
-### 1) Creating the transport channel
-
-`ProcBuilder::with_data_streams()` allocates an in-memory duplex stream:
-
-- `tokio::io::duplex(PIPE_BUFFER_SIZE)` yields `(host_stream, guest_stream)`.
-- `host_stream` stays on the host; `guest_stream` is injected into the
-  guest runtime state (`ComponentRunStates.data_stream`).
-
-Reference: `src/cell/proc.rs`
-
-```
-tokio::io::duplex()  ->  host_stream  <----->  guest_stream
+```text
+Host                                      WASM guest
+----                                      ----------
+tokio::io::DuplexStream                   wetware:streams connection
+        |                                 WASI input/output streams
+        v                                         |
+VatNetwork + RpcSystem <--- Cap'n Proto RPC ----> VatNetwork + RpcSystem
 ```
 
-### 2) Exposing to the agent as WASI io/streams
+The stream has no libp2p or OS-socket hop. `crates/cell/src/proc.rs` exposes
+the guest end as WASI stream resources and returns the host end through
+`DataStreamHandles`.
 
-When the agent calls `wetware:streams/streams#create-connection`, the host
-replaces the `guest_stream` with WASI stream resources:
+### PID0 bootstrap
 
-- Split guest stream into read/write halves.
-- Wrap them as `AsyncReadStream` and `AsyncWriteStream`.
-- Store them in a `ConnectionState` resource.
+`src/executor.rs` passes the host stream halves to
+`build_pid0_membrane_rpc()`. The host serves a process-local `Membrane` as the
+bootstrap capability.
 
-Reference: `src/cell/proc.rs`
+PID0 calls `Membrane.graft()`, which returns `List(Export)`. The canonical
+exports are:
 
-```
-guest_stream
-  -> split (guest_read, guest_write)
-  -> DynInputStream (AsyncReadStream)
-  -> DynOutputStream (AsyncWriteStream)
-```
+- `identity`, when a signing key is configured;
+- `host`;
+- `runtime`;
+- `routing`;
+- `authority`;
+- `ipfs`;
+- `http-client`, when an outbound HTTP allowlist is configured.
 
-### 3) Wiring Cap'n Proto RPC over the host side
+The host can also append explicitly configured extra exports. Graft-issued
+host capabilities use the PID0 generation's epoch guard.
 
-`ExecutorImpl::spawn()` in the host sets up the child process and builds a Cap'n Proto
-`VatNetwork` over the host's stream halves:
+### Ordinary-child bootstrap
 
-- `handles.take_host_split()` yields `(reader, writer)`.
-- `build_peer_rpc(reader, writer, wasm_debug)` wraps them in a `VatNetwork`.
-- A `RpcSystem` is spawned in a local task set alongside the guest process.
+`src/launcher.rs` passes the host stream halves and the child's
+`InitialAuthorityRecord` to `build_initial_authority_rpc()`. The host serves
+`InitialGrants`, whose `get()` method returns exactly the immutable
+parent-selected `List(Export)`.
 
-Reference: `src/rpc/mod.rs`
+An ordinary child does not receive `Membrane.graft()`. The host does not add
+PID0 exports to the child's record.
 
-```
-host_stream -> split -> (AsyncRead, AsyncWrite) -> VatNetwork -> RpcSystem
-```
+### Guest setup
 
-## Transport plumbing: guest side
+`RpcSession::connect()` in `std/system/src/lib.rs` performs the guest setup:
 
-### 1) Guest stream connection
+1. Call `create_connection()` once.
+2. Take the connection's input and output streams once.
+3. Wrap the streams in `StreamReader` and `StreamWriter`.
+4. Construct the guest `VatNetwork` and `RpcSystem`.
+5. Bootstrap the host-provided `Membrane` or `InitialGrants` capability.
 
-`RpcSession::connect()` in the guest SDK calls the WIT binding
-`create_connection()` and obtains a WASI input and output stream:
+`system::run()` drives the RPC system with an async guest closure.
+`system::run_with()` also includes caller-provided `PollSet` entries.
+`system::serve()` additionally exports one guest bootstrap capability.
+The parent can retrieve that guest export through `Process.bootstrap()`.
 
-- `create_connection()` -> `connection.get_input_stream()` and
-  `connection.get_output_stream()`.
-- These are wrapped as `StreamReader` and `StreamWriter`.
+`system::serve_stdio()` is separate. It serves a guest capability over WASI
+stdin/stdout and does not connect to the process-local host bootstrap.
 
-Reference: `std/system/src/lib.rs`
+## Network protocol boundary
 
-```
-create_connection()
-  -> WASI InputStream  -> StreamReader (AsyncRead)
-  -> WASI OutputStream -> StreamWriter (AsyncWrite)
-```
+Wetware publishes network services only below these protocol prefixes:
 
-### 2) Cap'n Proto RPC over WASI streams
+| Prefix | Payload | Host capabilities |
+|--------|---------|-------------------|
+| `/ww/0.1.0/vat/{protocol}` | Cap'n Proto RPC | `VatListener`, `VatClient` |
+| `/ww/0.1.0/stream/{protocol}` | Application-defined bytes | `StreamListener`, `StreamDialer` |
 
-The guest constructs a Cap'n Proto `VatNetwork` over those stream adapters
-and bootstraps a client:
+The bare `/ww/0.1.0` compatibility publication no longer exists. The
+process-local PID0 `Membrane` is not a network bootstrap.
 
-Reference: `std/system/src/lib.rs`
+Protocol names are locators. They do not carry authority or schema identity.
+The protocol constructors reject empty names and names that contain `/`.
 
-```
-StreamReader/StreamWriter -> VatNetwork -> RpcSystem -> client
-```
+### Vat services
 
-## Scheduling model and CPU behavior
+`VatListener` publishes an existing capability. It does not load or spawn a
+WASM process.
 
-Agents are not busy-spinning when idle. They run a cooperative event
-loop in `poll_loop`:
+- `serveRaw(cap, protocol)` accepts a vat stream and exposes `cap` directly.
+  This method is the explicit unauthenticated escape hatch.
+- `serveAuthenticated(cap, protocol, policy)` creates a fresh, single-use
+  `Terminal` for each inbound stream. The `Terminal` releases policy-selected
+  authority only after login succeeds within the configured deadline.
 
-1) Poll the RPC system and any application futures/promises.
-2) If no progress is made, block in `wasi_poll::poll` on stream readiness
-   (pollable handles from the WASI streams).
+Both methods stop their accept loops when their epoch guard becomes stale.
+Connection budgets limit concurrent inbound streams.
 
-Reference: `std/system/src/lib.rs`
+`VatClient.dial(peer, protocol)` opens the named vat stream and returns the
+remote bootstrap capability. `connect()` in `crates/rpc/src/vat_dial.rs`
+starts the client-side `RpcSystem` driver before returning the capability. The
+caller's first typed method response reports bootstrap or transport failure.
 
-Key points:
-- **No constant CPU polling**: when nothing makes progress, the agent
-  blocks on `wasi_poll::poll`, yielding to the host runtime.
-- **Asynchronous on the host**: the host side uses Tokio async I/O and a
-  spawned `RpcSystem` to process messages without blocking the host thread.
-- **Double-poll pattern**: `poll_loop` calls `rpc_system.poll`
-  twice per iteration — once before and once after `poll_work` — to flush
-  RPC writes the user future queued before blocking in `wasi_poll`. Missing
-  the second poll causes deadlock: calls queued during `poll_work` are never
-  sent, and the host never responds.
-
-```
-loop:
-  poll_rpc        -- deliver inbound messages
-  poll_future     -- run application logic (may queue outbound RPC)
-  poll_rpc        -- flush outbound messages
-  if done -> exit
-  if no progress -> wasi_poll::poll([reader, writer])
-```
-
-## End-to-end flows
-
-### Flow A: pid0 spawns a child agent
-
-```
-pid0 (kernel)               host                        child agent
-─────────────              ──────                      ─────────────
-Membrane.graft() -> host grants
-load+spawn(explicit grants) ─> spawn child Proc + InitialGrants RpcSystem
-                           return Process cap
-wait RPC     <──────────── ProcessImpl::wait
+```text
+publisher                                         remote peer
+---------                                         -----------
+existing capability
+        |
+VatListener.serveAuthenticated()
+        |
+fresh Terminal <--- /ww/0.1.0/vat/{protocol} ---> VatClient.dial()
 ```
 
-### Flow B: child loads + spawns a grandchild
+### Byte-stream services
 
-```
-child agent (with Runtime grant)    host
-───────────────────────────────     ──────
-runtime.load(wasm) ───────────────> RuntimeImpl::load (cache lookup or compile)
-  -> Executor client <──── return pipelined Executor
-executor.spawn()   ──────> ExecutorImpl::spawn
-  -> Process client <───── return Process cap
-```
+`StreamListener.listen(executor, protocol, caps)` registers a named byte-stream
+handler. For each inbound `/ww/0.1.0/stream/{protocol}` connection, the
+listener:
 
-## Transport diagram (host/guest boundary)
+1. spawns one process through the supplied `Executor`;
+2. copies the registration-time `List(Export)` into the child's initial grants;
+3. pumps the network stream to the child's stdin;
+4. pumps the child's stdout to the network stream.
 
-```
-Guest code (WASM)                           Host (Tokio + Wasmtime)
-─────────────────                          ────────────────────────
-RpcSession::connect()                      ProcBuilder::with_data_streams()
-  create_connection()  <WIT>              create duplex (host/guest)
-  get_input_stream()   <WIT>              map to AsyncReadStream
-  get_output_stream()  <WIT>              map to AsyncWriteStream
-  StreamReader/Writer                      host_stream split
-        |                                        |
-        v                                        v
-  VatNetwork + RpcSystem                VatNetwork + RpcSystem
-        |                                        |
-        +------------- Cap'n Proto RPC ----------+
-```
+`StreamDialer.dial(peer, protocol)` opens the named stream and returns a
+bidirectional `ByteStream` capability. The bytes have application-defined
+semantics.
 
-## Cell I/O semantics
+This raw stream path differs from vat publication. `StreamListener` spawns a
+process and wires bytes. `VatListener` serves an existing capability through a
+Cap'n Proto `RpcSystem`.
 
-All cell types get `with_data_streams()` + membrane RPC. The WIT membrane
-channel is universal. What differs is the stdin/stdout semantics:
+### HTTP registration
 
-| Cell type | stdin carries | stdout carries |
-|-----------|--------------|----------------|
-| **Raw** (`Cell::raw`) | Wire protocol bytes (libp2p stream) | Wire protocol bytes |
-| **HTTP/WAGI** (`Cell::http`) | CGI request body (RFC 3875) | CGI response |
-| **Cap'n Proto** (`Cell::capnp`) | Shutdown signal only (close = graceful exit) | Unused |
-| **pid0** (no cell section) | Host terminal / daemon stdin | Host terminal |
+`HttpListener.listen(executor, prefix, caps)` is another explicit registration
+path. It creates an HTTP route, spawns one process per request, supplies CGI
+environment variables and request bytes, and reads the CGI response from
+stdout. The host does not select HTTP, byte-stream, or vat behavior from a
+WASM custom section.
 
-For Cap'n Proto (RPC) cells, stdin is a shutdown signal channel, not a data
-transport. The host never writes bytes. All RPC I/O goes through the WIT
-data_streams side-channel.
+## Guest scheduling
 
-Vat publication is publisher-owned: the publisher spawns a cell, imports its
-guest-exported capability with `Process.bootstrap()`, and passes that capability plus
-an explicit auth policy to `VatListener.serveAuthenticated`. The listener owns
-one Terminal and login deadline per stream, but it does not own or spawn the
-publishing cell. `handle_vat_connection_serve` is retained for the explicit
-raw-serving path.
+WASM guests use the cooperative `poll_loop` in `std/system/src/lib.rs`. Each
+cycle performs these actions:
 
-`Process.bootstrap()` is parent-held guest-exported authority, not the
-host-provided `InitialGrants` that bootstraps an ordinary child.
+1. Poll the guest `RpcSystem` for inbound work.
+2. Poll the application future.
+3. If the cycle wrote RPC bytes, poll the `RpcSystem` again to flush them.
+4. Block in `wasi:io/poll` on the RPC reader, optional writer, additional
+   `PollSet` entries, or the idle timeout.
 
-## Executor pool and M:N scheduling
+The second RPC poll is required after application work queues an outbound
+call. Without that poll, the guest can block before it sends the request.
 
-Cell processes run on an `ExecutorPool` of N worker threads (one per CPU core
-by default, configurable via `--executor-threads`). Each worker is an OS thread
-with a `current_thread` tokio runtime and a `LocalSet`, because `wasmtime::Store`
-is `!Send`.
+The writer participates in the poll set only after a write attempt. Otherwise,
+the loop includes a 100 ms monotonic-clock pollable as protection against a
+missed host-stream wakeup.
 
-Cells are assigned to the least-loaded worker at spawn time (with round-robin
-fallback for ties). Multiple cells on the same worker cooperatively share the
-thread via the EWMA fuel scheduler: cells yield every ~10K instructions at
-wasmtime host call boundaries, giving sibling cells a chance to run.
-See [fuel-scheduling.md](designs/fuel-scheduling.md) for the full design.
+Host-side `RpcSystem` instances run as local Tokio tasks. PID0 starts its driver
+in `src/executor.rs`. Ordinary children start their drivers in
+`src/launcher.rs`.
 
-Reference: `src/runtime.rs`
+## Executor scheduling
 
-## Notes and implications
+`ExecutorPool` in `src/services.rs` runs worker OS threads. Each worker has a
+current-thread Tokio runtime and a `LocalSet` because WASM stores and Cap'n
+Proto clients are local tasks. The pool assigns new cells to the least-loaded
+worker and uses round-robin assignment for equal loads.
 
-- The transport is **async** on the host and **poll-driven** on the guest
-  with explicit blocking on WASI pollables.
-- RPC messages traverse memory-only duplex streams; there is no OS socket I/O.
-- Backpressure is mediated by the WASI output stream budget (`check_write`)
-  and the duplex buffer size (`PIPE_BUFFER_SIZE`, currently 64 KiB).
-- `blocking_read()` inside a `system::run` closure is safe: wasmtime's async
-  machinery suspends the entire `call_async` future while waiting, yielding
-  the tokio thread. The poll loop resumes exactly where it left off.
+Scheduled cells use Wasmtime fuel for cooperative yielding. See
+[fuel-scheduling.md](designs/fuel-scheduling.md) for the scheduling policy.
 
-## Deadlock analysis and mitigations
+## Backpressure and lifetime
 
-The guest can deadlock if it blocks without a peer making progress, or if
-both ends wait for each other without driving their RPC systems. The
-transport itself is cooperative: it requires one side to be actively polled
-to move data.
+The process-local duplex stream uses `PIPE_BUFFER_SIZE` from
+`crates/cell/src/proc.rs`. Guest writes obey the WASI output stream's
+`check_write()` budget. Network byte-stream pumps use bounded chunks and wait
+for their readers and writers.
 
-### Deadlock causes
+The host keeps each process-local `RpcSystem` driver alive with the process.
+Dropping the driver closes the RPC path. Guest code must keep `system::run()`,
+`system::run_with()`, or `system::serve()` active while it awaits RPC promises.
 
-1) **Host stops driving the child RPC system.**
-   In `ExecutorImpl::spawn()`, the host spawns a local task to run the child's `RpcSystem`.
-   If that task is never scheduled (or exits early), the guest will block in
-   `wasi_poll::poll` waiting for read/write readiness that never comes.
+`Process.bootstrap()` is parent-held authority exported by a guest through
+`system::serve()`. It is distinct from the host-provided `InitialGrants`
+bootstrap that the ordinary child receives.
 
-2) **Guest waits on RPC promises without driving the poll loop.**
-   Cap'n Proto RPC futures only make progress when `rpc_system.poll`
-   is driven. If user code blocks or returns without continuing the
-   `poll_loop`, responses will never be delivered.
+## Deadlock constraints
 
-3) **Missing flush poll (the double-poll requirement).**
-   If the poll loop only calls `poll_rpc` once (before `poll_future`), RPC
-   calls queued during `future.poll` are never flushed to the wire before
-   `wasi_poll` blocks. The host never sees the request, the guest never
-   gets a response.
+The following constraints keep RPC progress possible:
 
-4) **Backpressure deadlock: both sides waiting on writable/readable state.**
-   If the guest's writer is not ready and the host's reader isn't draining
-   (or vice versa), both sides can become stuck waiting for readiness.
-   The guest-side `StreamWriter` reports readiness via `check_write`; if
-   it repeatedly returns 0, the driver waits for readiness with
-   `wasi_poll::poll`.
+- The host must poll the process's `RpcSystem` while the process is active.
+- The guest must poll its `RpcSystem` while it awaits derived promises.
+- The guest poll loop must flush calls queued by the application future before
+  it blocks on WASI pollables.
+- A vat dialer must start its `RpcSystem` before awaiting a derived promise.
+- Application protocols must avoid call cycles in which both peers wait for
+  callbacks that neither peer can poll.
 
-5) **Application-level wait cycles.**
-   A guest can block awaiting a host response that itself depends on a
-   guest callback or further guest progress (capability-based cycles).
-   This shows up when the guest stops polling while the host expects a
-   follow-up message from the same guest.
-
-6) **Client-side dial: awaiting a derived promise before spawning the
-   RpcSystem.** This is a client-side analog of cause (1), specific to
-   code that *dials* a remote vat, including `VatClient::dial()` for outgoing
-   guest dials. The buggy shape:
-
-   ```rust
-   // BUG: when_resolved() / .send().promise / etc. registers a waker
-   //      on RpcSystem-internal state that never advances because no
-   //      one is polling the system. Deadlock until the timeout fires.
-   let mut rpc_system = RpcSystem::new(network, None);
-   let client = rpc_system.bootstrap(Side::Server);
-   client.when_resolved().await?;                  // <-- hangs forever
-   tokio::task::spawn_local(rpc_system);           // never reached
-   ```
-
-   A second, capnp-rpc-rust-internal quirk compounds the first:
-   `when_resolved()` on a fresh `PromiseClient` does not reliably
-   fire even with correct ordering in capnp-rpc-rust 0.25
-   (`when_more_resolved` keeps appending waiters to an already-drained
-   queue after `PromiseClient::resolve`). The canonical
-   [capnproto-rust hello-world client] sidesteps this entirely by going
-   straight to method calls — the response promise IS the handshake
-   observable.
-
-   The removed `ww shell` path originally surfaced this defect as #450, with a
-   30-second handshake timeout on every connection.
-
-   [capnproto-rust hello-world client]: https://github.com/capnproto/capnproto-rust/blob/master/capnp-rpc/examples/hello-world/client.rs
-
-### Mitigations
-
-1) **Ensure both RPC systems are continuously driven.**
-   Host: keep the child's `RpcSystem` alive for the lifetime of the guest
-   process. Guest: keep the poll loop running whenever promises are
-   outstanding.
-
-2) **Use the double-poll pattern.**
-   Always call `poll_rpc` both before and after `poll_work` in the
-   poll loop. This is the single most common deadlock fix.
-
-3) **Use timeouts on long-lived RPC calls.**
-   On the guest, wrap poll-driven workflows with timeouts and error
-   if no progress is made for a window. On the host,
-   bound guest process execution (`tokio::time::timeout`).
-
-4) **Add explicit yield points in agents.**
-   If an agent performs long CPU work, ensure it periodically drives the
-   RPC system and yields to pollables. Without this, inbound RPC traffic
-   will stall.
-
-5) **Tune buffer size.**
-   Increase `PIPE_BUFFER_SIZE` or chunk writes to reduce long stalls when
-   one side is briefly slow to drain.
-
-6) **Observability.**
-   Keep trace logging enabled during development to detect stalled states
-   and verify that the RPC system is being polled.
-
-7) **Use the `vat_dial` paved-path helper for client-side dials.**
-   For any code that dials a remote vat (host-side CLI, the
-   `VatClient::dial()` capability impl, future internal callers), use
-   [`crates/rpc/src/vat_dial.rs::connect`] instead of building the
-   `RpcSystem` + `VatNetwork` + `bootstrap()` chain by hand.  The helper
-   spawns the driver *before* returning the typed bootstrap client, so
-   callers structurally cannot reproduce cause (6).  Returns
-   `VatDial<C>` carrying the typed cap plus a `JoinHandle` for the
-   detached driver; the driver flushes the Bootstrap message and
-   receives the remote Return on its own, with no handshake-check
-   `await` needed.  Regression tests live alongside the helper.
-
-   **Trade-off** (accepted, documented in the helper's module docs):
-   `vat_dial::connect` does not synchronously verify the remote
-   responded to Bootstrap before returning the cap.  In the rare case
-   that the peer accepts the libp2p subprotocol stream but doesn't
-   actually speak Cap'n Proto, the failure surfaces on the caller's
-   first method call via that call's own timeout rather than as a distinct
-   "handshake timeout"
-   at connect.  Time-to-failure is unchanged (~30s either way);
-   diagnostic precision is slightly reduced.  Acceptable because libp2p
-   subprotocol negotiation already established the peer claims to speak
-   our exact capnp interface, the canonical capnproto-rust pattern
-   operates the same way, and the alternative (`when_resolved` await)
-   was empirically broken in capnp-rpc-rust 0.25.  In every other
-   scenario the new behaviour is a strict improvement: no 30s connect
-   penalty for dials that never make a method call, no synchronous wait
-   for cold-cache WASM compile on the other side, etc.
-
-   [`crates/rpc/src/vat_dial.rs::connect`]: ../crates/rpc/src/vat_dial.rs
-
-## Open questions
-
-- **Duplex buffer size.** The current `PIPE_BUFFER_SIZE` (64 KiB) was
-  chosen pragmatically. Profiling under realistic RPC payloads may suggest
-  a different value.
-- **WASI io/streams linkage.** The stream setup currently lives in `Proc`.
-  It may be worth lifting to a shared helper if additional agent types
-  (e.g. `crates/proc/` stream handlers) need the same plumbing.
+Host-side vat clients use `connect()` in `crates/rpc/src/vat_dial.rs` for the
+required driver-before-await ordering. Guest code uses the `system` crate
+entry points instead of constructing an undriven `RpcSystem`.


### PR DESCRIPTION
## Summary

Final post-Glia documentation correctness and hardening pass. This PR changes documentation and agent guidance only.

The diff fixes exactly six issue groups:

1. Correct `doc/api/wasm-guest.md` graft exports, IPFS surfaces, `ready-error`, `Executor.cid`, `Process.kill`, and `system::run_with`.
2. Document `/readyz` as `kernel_ready && routes_ready` and qualify PID0 lifetime for `WW_TTY` stdin EOF.
3. Replace the obsolete custom-section transport model and stale source paths in `doc/rpc-transport.md`.
4. Remove nonexistent APIs and tooling from `.agents/skills/` and document current graft and transport APIs.
5. Add the real `ipfs` graft capability to `doc/capabilities.md` while keeping `Ipfs.read()` distinct from WASI filesystem access.
6. State that PID0 normally waits for Host termination while `WW_TTY` execution can end on stdin EOF or read failure.

## Verified current behavior

- Graft exports: `identity` when configured, `host`, `runtime`, `routing`, `authority`, `ipfs`, `http-client` when configured, and explicit extras.
- Vat methods: `VatListener.serveRaw` and `VatListener.serveAuthenticated`.
- Protocol namespaces: `/ww/0.1.0/vat/*` and `/ww/0.1.0/stream/*`.
- Bare `/ww/0.1.0` compatibility publication remains removed.
- `Ipfs.read(path)` is an explicit RPC capability and does not replace WASI filesystem access.

## Validation

- `git diff --check`
- Focused graft test passed.
- Focused `/readyz` test passed.
- Obsolete identifier search returned zero matches.
- Modified-file relative links passed.
- Markdown fence checks passed.
- Skill `reads:` checks passed.
- Transport source-path checks passed.

No changelog entry is required because every changed path is exempt under `.github/workflows/changelog.yml`.

## Independent review

Independent read-only review returned `CLEAR WITH NON-BLOCKING NOTES` and confirmed that all six issue groups match current source.

## Deferred follow-up

`capnp/membrane.capnp` remains unchanged. Its canonical-name comment omits `authority`, although production graft code exports it. That non-blocking correction is outside this PR boundary.