### PR TITLE
fix: keep private host state out of deployment images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Changed
+- **Default daemon images no longer publish private host state.** Installed
+  daemons import only `~/.ww/fhs` as their default deployment image. Identity
+  and namespace configuration remain host-side. Updates rewrite vulnerable
+  service definitions and restart the daemon when image content, default FHS
+  content, or the rendered service definition changes. Explicit images and
+  direct `ww run` behavior remain unchanged.
 - **Deployment lifecycle now has one host-side owner.** New `ww::stem` and
   `ww::deployment` modules replace `crates/stem`, `cell::epoch`, and
   `EpochService`. The Atom Source reads `Atom.head()` at finalized chain depth

--- a/doc/images.md
+++ b/doc/images.md
@@ -34,6 +34,29 @@ as layers (later mounts override earlier ones):
 
 Targeted mounts (`source:/guest/path`) are not accepted by backend virtual mode.
 
+## Installed host layout
+
+`ww perform install` and `ww perform update` separate private host state from
+the local image root:
+
+```
+~/.ww/
+  identity              # private node identity
+  etc/ns/               # host-only namespace configuration
+  logs/                  # host logs
+  run/                   # host runtime state
+  fhs/                   # publishable local image root
+    bin/status.wasm      # status component used by the shipped Rust PID0
+```
+
+The generated service recursively imports only `~/.ww/fhs` and explicit image
+arguments. The service reads `~/.ww/etc/ns` through a separate host-only
+configuration argument. The service does not mount `~/.ww` as an image.
+
+Put intentional local image content under `~/.ww/fhs`, or pass an explicit
+image path to `ww daemon install`. Do not put private host state in an image
+root because Kubo can store, pin, and provide every imported file.
+
 ## On-chain coordination
 
 The `--stem` flag connects to an Atom contract on an EVM chain.

--- a/doc/keys.md
+++ b/doc/keys.md
@@ -35,7 +35,7 @@ challenge-response auth uses `try_into_ed25519()`. Guest auth
 
 Keys are stored as **base58btc** (Bitcoin alphabet, ~44 characters for 32 bytes)
 in a plain text file. Hex-encoded keys are also accepted on load for backward
-compatibility. The default location is `~/.ww/key`.
+compatibility. The default location is `~/.ww/identity`.
 
 Rationale:
 - Denser than hex (44 vs 64 chars), no ambiguous characters (no 0/O/I/l).
@@ -43,8 +43,9 @@ Rationale:
 - Key files belong on encrypted volumes or in a secrets manager at the
   infrastructure level, not wrapped in application-level encryption that just
   moves the password storage problem.
-- Private key material **never touches IPFS** or any other content-addressed
-  store. Even if the node CID is public, the key file stays local.
+- The installed daemon reads `~/.ww/identity` through `--identity`. Its default
+  image root is `~/.ww/fhs`, so the identity file does not enter the imported
+  image DAG. An explicit image path can still expose any key inside that path.
 
 ### Identity resolution
 
@@ -72,17 +73,17 @@ For daemon/service mode, pass identity through the same host flags/env:
 ww keygen
 
 # Save to a file
-ww keygen --output ~/.ww/key
-ww keygen > ~/.ww/key          # equivalent
+ww keygen --output ~/.ww/identity
+ww keygen > ~/.ww/identity          # equivalent
 
 # Run with a persistent identity
-ww run --identity ~/.ww/key images/my-app
+ww run --identity ~/.ww/identity images/my-app
 ```
 
 ## File format
 
 ```
-# ~/.ww/key — base58btc, ~44 chars (hex also accepted on load)
+# ~/.ww/identity — base58btc, ~44 chars (hex also accepted on load)
 6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5
 ```
 
@@ -92,7 +93,7 @@ ww run --identity ~/.ww/key images/my-app
 $ ww keygen 2>/dev/null
 6MRyAjQq8ud7hVNYcfnVPJqcVpscN5So8BhtHuGYqET5
 
-$ ww keygen --output ~/.ww/key
-Secret written to: /home/user/.ww/key
+$ ww keygen --output ~/.ww/identity
+Secret written to: /home/user/.ww/identity
 Peer ID:        12D3KooWAbcDef...
 ```

--- a/src/cli/daemon_cmd.rs
+++ b/src/cli/daemon_cmd.rs
@@ -17,6 +17,8 @@ pub(super) fn default_listen() -> Vec<String> {
 pub(super) struct DaemonServiceConfig {
     pub listen: Vec<String>,
     pub identity: PathBuf,
+    /// Host-only roots whose `etc/ns` directories configure namespace layers.
+    pub namespace_roots: Vec<PathBuf>,
     pub images: Vec<PathBuf>,
     /// Address (`host:port`) for the WAGI HTTP server. `None` disables WAGI.
     pub http_listen: Option<String>,
@@ -25,13 +27,14 @@ pub(super) struct DaemonServiceConfig {
 /// Register wetware as a user-level background service.
 ///
 /// When `quiet` is true, suppresses status output (used by `perform install`
-/// which prints its own summary).
+/// which prints its own summary). Returns whether the rendered service
+/// definition differs from the definition that was on disk.
 pub(super) async fn daemon_install(
     identity: Option<PathBuf>,
     listen: Vec<Multiaddr>,
     images: Vec<String>,
     quiet: bool,
-) -> Result<()> {
+) -> Result<bool> {
     let home = dirs::home_dir().context("cannot determine home directory")?;
     let ww_dir = home.join(".ww");
 
@@ -59,25 +62,67 @@ pub(super) async fn daemon_install(
         listen.iter().map(|a| a.to_string()).collect()
     };
 
-    let image_layers = if images.is_empty() {
-        vec![ww_dir]
+    let (namespace_roots, image_layers) = if images.is_empty() {
+        let (fhs_dir, _) = refresh_default_fhs(&ww_dir)?;
+        (vec![ww_dir.clone()], vec![fhs_dir])
     } else {
-        images.iter().map(PathBuf::from).collect()
+        (Vec::new(), images.iter().map(PathBuf::from).collect())
     };
 
     // Default WAGI HTTP listener so Rust PID0 responds to curl on first boot.
     let config = DaemonServiceConfig {
         listen: listen_addrs,
         identity: key_path.clone(),
+        namespace_roots,
         images: image_layers,
         http_listen: Some("127.0.0.1:2080".to_string()),
     };
 
     // 3. Write platform service file.
     let ww_bin = std::env::current_exe().context("cannot determine ww binary path")?;
-    write_service_file(&ww_bin, &config, &home, quiet)?;
+    write_service_file(&ww_bin, &config, &home, quiet)
+}
 
-    Ok(())
+/// Materialize the install-owned FHS layer outside the private host-state tree.
+///
+/// Release binaries carry the status component. Install-script layouts from
+/// older versions provide the same bytes under `~/.ww/std/status`.
+pub(super) fn refresh_default_fhs(ww_dir: &Path) -> Result<(PathBuf, bool)> {
+    let fhs_dir = ww_dir.join("fhs");
+    let bin_dir = fhs_dir.join("bin");
+    let mut changed = !bin_dir.exists();
+    std::fs::create_dir_all(&bin_dir).context("create ~/.ww/fhs/bin")?;
+
+    let status_path = bin_dir.join("status.wasm");
+    let legacy_status_path = ww_dir.join("std/status/bin/status.wasm");
+    let status_bytes = if !super::EMBEDDED_STATUS.is_empty() {
+        Some(super::EMBEDDED_STATUS.to_vec())
+    } else {
+        match std::fs::read(&legacy_status_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error)
+                    .with_context(|| format!("read {}", legacy_status_path.display()));
+            }
+        }
+    };
+    if let Some(status_bytes) = status_bytes {
+        let current = match std::fs::read(&status_path) {
+            Ok(bytes) => Some(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => None,
+            Err(error) => {
+                return Err(error).with_context(|| format!("read {}", status_path.display()));
+            }
+        };
+        if current.as_deref() != Some(status_bytes.as_slice()) {
+            std::fs::write(&status_path, status_bytes)
+                .context("write ~/.ww/fhs/bin/status.wasm")?;
+            changed = true;
+        }
+    }
+
+    Ok((fhs_dir, changed))
 }
 
 /// Remove the platform service file.
@@ -116,12 +161,13 @@ pub(super) async fn daemon_uninstall() -> Result<()> {
 }
 
 /// Write a platform-specific service file and print the activation command.
+/// Returns whether the rendered definition differs from the prior file bytes.
 pub(super) fn write_service_file(
     ww_bin: &Path,
     config: &DaemonServiceConfig,
     home: &Path,
     quiet: bool,
-) -> Result<()> {
+) -> Result<bool> {
     // Identity as a --identity CLI flag (NOT a :/etc/identity mount).
     // The host reads it to create the signing key; it never enters
     // the merged FHS tree visible to guests.
@@ -136,6 +182,14 @@ pub(super) fn write_service_file(
     }
 }
 
+fn service_definition_differs(path: &Path, definition: &[u8]) -> Result<bool> {
+    match std::fs::read(path) {
+        Ok(existing) => Ok(existing != definition),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(true),
+        Err(error) => Err(error).with_context(|| format!("read {}", path.display())),
+    }
+}
+
 /// Write a macOS launchd plist.
 pub(super) fn write_launchd_plist(
     ww_bin: &Path,
@@ -143,7 +197,7 @@ pub(super) fn write_launchd_plist(
     home: &Path,
     identity_path: &str,
     quiet: bool,
-) -> Result<()> {
+) -> Result<bool> {
     let plist_dir = home.join("Library/LaunchAgents");
     std::fs::create_dir_all(&plist_dir).context("create ~/Library/LaunchAgents")?;
 
@@ -169,6 +223,11 @@ pub(super) fn write_launchd_plist(
     if let Some(ref addr) = config.http_listen {
         args.push("        <string>--http-listen</string>".to_string());
         args.push(format!("        <string>{addr}</string>"));
+    }
+    // Namespace configuration is host state, not an image mount.
+    for root in &config.namespace_roots {
+        args.push("        <string>--namespace-root</string>".to_string());
+        args.push(format!("        <string>{}</string>", root.display()));
     }
     // Image layers (root mounts).
     for img in &config.images {
@@ -207,6 +266,7 @@ pub(super) fn write_launchd_plist(
         log = log_path.display(),
     );
 
+    let changed = service_definition_differs(&plist_path, plist.as_bytes())?;
     std::fs::write(&plist_path, plist)
         .with_context(|| format!("write plist: {}", plist_path.display()))?;
     if !quiet {
@@ -216,7 +276,7 @@ pub(super) fn write_launchd_plist(
         eprintln!("  launchctl load {}", plist_path.display());
     }
 
-    Ok(())
+    Ok(changed)
 }
 
 /// Write a Linux systemd user unit.
@@ -226,7 +286,7 @@ pub(super) fn write_systemd_unit(
     home: &Path,
     identity_path: &str,
     quiet: bool,
-) -> Result<()> {
+) -> Result<bool> {
     let unit_dir = home.join(".config/systemd/user");
     std::fs::create_dir_all(&unit_dir).context("create ~/.config/systemd/user")?;
 
@@ -248,12 +308,19 @@ pub(super) fn write_systemd_unit(
         Some(addr) => format!(" --http-listen {addr}"),
         None => String::new(),
     };
+    let namespace_args = config
+        .namespace_roots
+        .iter()
+        .map(|root| format!("--namespace-root {}", root.display()))
+        .collect::<Vec<_>>()
+        .join(" ");
     let exec_start = format!(
-        "{} run {} --identity {}{} {}",
+        "{} run {} --identity {}{} {} {}",
         ww_bin.display(),
         listen_args,
         identity_path,
         http_listen_arg,
+        namespace_args,
         positional.join(" "),
     );
 
@@ -273,6 +340,7 @@ pub(super) fn write_systemd_unit(
          WantedBy=default.target\n"
     );
 
+    let changed = service_definition_differs(&unit_path, unit.as_bytes())?;
     std::fs::write(&unit_path, unit)
         .with_context(|| format!("write unit: {}", unit_path.display()))?;
     if !quiet {
@@ -282,5 +350,5 @@ pub(super) fn write_systemd_unit(
         eprintln!("  systemctl --user enable --now ww");
     }
 
-    Ok(())
+    Ok(changed)
 }

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -81,6 +81,7 @@ struct Cli {
 }
 
 #[derive(Subcommand)]
+#[allow(clippy::large_enum_variant)]
 enum Commands {
     /// Initialize a new typed cell guest project.
     ///
@@ -117,6 +118,10 @@ enum Commands {
         /// Mount source(s) at `/` (image layers).
         #[arg(default_value = ".", value_name = "MOUNT")]
         mounts: Vec<String>,
+
+        /// Host-only roots whose `etc/ns` directories configure namespace layers.
+        #[arg(long, value_name = "PATH", hide = true)]
+        namespace_root: Vec<PathBuf>,
 
         /// libp2p listen multiaddr. Repeatable; comma-separated via WW_LISTEN.
         /// Defaults to TCP and QUIC on both IPv4 and IPv6 at port 2025.
@@ -722,6 +727,7 @@ impl Commands {
             Commands::Build { path } => Self::build(path).await,
             Commands::Run {
                 mounts: mount_args,
+                namespace_root,
                 listen,
                 wasm_debug,
                 kernel,
@@ -764,6 +770,7 @@ impl Commands {
                 };
                 Self::run_with_mounts(
                     mounts,
+                    namespace_root,
                     identity_path,
                     insecure_ephemeral,
                     listen,
@@ -806,7 +813,9 @@ impl Commands {
                     identity,
                     listen,
                     images,
-                } => Self::daemon_install(identity, listen, images, false).await,
+                } => Self::daemon_install(identity, listen, images, false)
+                    .await
+                    .map(|_| ()),
                 DaemonAction::Uninstall => Self::daemon_uninstall().await,
             },
             Commands::Push {
@@ -1412,7 +1421,7 @@ wasip2::cli::command::export!({iface_name}Guest);
         listen: Vec<Multiaddr>,
         images: Vec<String>,
         quiet: bool,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         daemon_cmd::daemon_install(identity, listen, images, quiet).await
     }
 
@@ -1425,6 +1434,7 @@ wasip2::cli::command::export!({iface_name}Guest);
     #[allow(clippy::too_many_arguments)]
     async fn run_with_mounts(
         mounts: Vec<ww::cell::mount::Mount>,
+        namespace_roots: Vec<PathBuf>,
         identity: Option<PathBuf>,
         insecure_ephemeral: bool,
         listen: Vec<Multiaddr>,
@@ -1469,7 +1479,12 @@ wasip2::cli::command::export!({iface_name}Guest);
             .filter(|mount| mount.is_root() && !ww::ipfs::is_ipfs_path(&mount.source))
             .map(|mount| std::path::Path::new(&mount.source))
             .collect();
-        let ns_configs = ww::ns::scan_namespace_configs(&local_roots)
+        let namespace_scan_roots: Vec<&std::path::Path> = namespace_roots
+            .iter()
+            .map(PathBuf::as_path)
+            .chain(local_roots.iter().copied())
+            .collect();
+        let ns_configs = ww::ns::scan_namespace_configs(&namespace_scan_roots)
             .context("Failed to scan namespace configs")?;
 
         ww::config::init_tracing_to_stderr(false);
@@ -2259,16 +2274,17 @@ wasip2::cli::command::export!({iface_name}Guest);
             }
         }
 
-        // ── Daemon config + service file (unconditional) ─────────────
+        // ── Install-owned FHS + daemon service file (unconditional) ──
         let identity_path = ww_dir.join("identity");
-        // Mount ~/.ww as the single root layer. WASM cells are resolved
-        // from the embedded loader or IPNS namespace.
-        let image_layers: Vec<String> = vec![ww_dir.display().to_string()];
-        Self::daemon_install(Some(identity_path), Vec::new(), image_layers, true).await?;
+        let (_, install_layer_changed) = daemon_cmd::refresh_default_fhs(&ww_dir)?;
+        // Empty images select ~/.ww/fhs and read ~/.ww/etc/ns through the
+        // separate host-only namespace root.
+        let service_definition_changed =
+            Self::daemon_install(Some(identity_path), Vec::new(), Vec::new(), true).await?;
         done("Background daemon".into());
 
-        // ── Restart daemon (only if images changed) ─────────────────
-        if !any_images_changed {
+        // ── Restart daemon when deployed content or its boundary changed ─
+        if !any_images_changed && !install_layer_changed && !service_definition_changed {
             skip("Daemon restart (nothing changed)".into());
         } else {
             match Self::restart_user_daemon(&home) {
@@ -2903,6 +2919,7 @@ mod tests {
     fn test_run_command_rejects_targeted_mounts_preflight() {
         let cmd = Commands::Run {
             mounts: vec![".".to_string(), "~/.ww/identity:/etc/identity".to_string()],
+            namespace_root: Vec::new(),
             listen: Vec::new(),
             wasm_debug: false,
             kernel: None,
@@ -3144,6 +3161,7 @@ mod tests {
         daemon_cmd::DaemonServiceConfig {
             listen: vec!["/ip4/0.0.0.0/tcp/2025".to_string()],
             identity: PathBuf::from("/tmp/identity"),
+            namespace_roots: vec![PathBuf::from("/tmp/host-state")],
             images: Vec::new(),
             http_listen: Some(addr.to_string()),
         }
@@ -3153,6 +3171,7 @@ mod tests {
         daemon_cmd::DaemonServiceConfig {
             listen: vec!["/ip4/0.0.0.0/tcp/2025".to_string()],
             identity: PathBuf::from("/tmp/identity"),
+            namespace_roots: Vec::new(),
             images: Vec::new(),
             http_listen: None,
         }
@@ -3164,8 +3183,15 @@ mod tests {
         let config = config_with_http_listen("127.0.0.1:2080");
         let ww_bin = std::path::Path::new("/usr/local/bin/ww");
 
-        daemon_cmd::write_launchd_plist(ww_bin, &config, home.path(), "/tmp/identity", true)
-            .expect("write plist should succeed");
+        let changed =
+            daemon_cmd::write_launchd_plist(ww_bin, &config, home.path(), "/tmp/identity", true)
+                .expect("write plist should succeed");
+        assert!(changed, "a missing plist should count as changed");
+
+        let changed =
+            daemon_cmd::write_launchd_plist(ww_bin, &config, home.path(), "/tmp/identity", true)
+                .expect("rewrite identical plist should succeed");
+        assert!(!changed, "an identical plist should not count as changed");
 
         let plist =
             std::fs::read_to_string(home.path().join("Library/LaunchAgents/io.wetware.ww.plist"))
@@ -3178,6 +3204,11 @@ mod tests {
         assert!(
             plist.contains("<string>127.0.0.1:2080</string>"),
             "plist should emit the configured listen address, got:\n{plist}"
+        );
+        assert!(
+            plist.contains("<string>--namespace-root</string>")
+                && plist.contains("<string>/tmp/host-state</string>"),
+            "plist should read namespace configuration through a host-only root, got:\n{plist}"
         );
     }
 
@@ -3206,8 +3237,15 @@ mod tests {
         let config = config_with_http_listen("127.0.0.1:2080");
         let ww_bin = std::path::Path::new("/usr/local/bin/ww");
 
-        daemon_cmd::write_systemd_unit(ww_bin, &config, home.path(), "/tmp/identity", true)
-            .expect("write unit should succeed");
+        let changed =
+            daemon_cmd::write_systemd_unit(ww_bin, &config, home.path(), "/tmp/identity", true)
+                .expect("write unit should succeed");
+        assert!(changed, "a missing unit should count as changed");
+
+        let changed =
+            daemon_cmd::write_systemd_unit(ww_bin, &config, home.path(), "/tmp/identity", true)
+                .expect("rewrite identical unit should succeed");
+        assert!(!changed, "an identical unit should not count as changed");
 
         let unit = std::fs::read_to_string(home.path().join(".config/systemd/user/ww.service"))
             .expect("unit should exist");
@@ -3215,6 +3253,10 @@ mod tests {
         assert!(
             unit.contains("--http-listen 127.0.0.1:2080"),
             "systemd unit should emit --http-listen flag with addr, got:\n{unit}"
+        );
+        assert!(
+            unit.contains("--namespace-root /tmp/host-state"),
+            "systemd unit should read namespace configuration through a host-only root, got:\n{unit}"
         );
     }
 
@@ -3234,5 +3276,33 @@ mod tests {
             !unit.contains("--http-listen"),
             "systemd unit should NOT emit --http-listen when config.http_listen is None, got:\n{unit}"
         );
+    }
+
+    #[test]
+    fn default_fhs_materializes_status_once() {
+        let home = tempfile::tempdir().expect("temp home");
+        let ww_dir = home.path().join(".ww");
+        let legacy_status = b"legacy status component";
+        let legacy_path = ww_dir.join("std/status/bin/status.wasm");
+        std::fs::create_dir_all(legacy_path.parent().expect("legacy status parent"))
+            .expect("create legacy status parent");
+        std::fs::write(&legacy_path, legacy_status).expect("write legacy status");
+
+        let (fhs_dir, changed) =
+            daemon_cmd::refresh_default_fhs(&ww_dir).expect("materialize default FHS");
+        assert!(changed);
+        let expected = if EMBEDDED_STATUS.is_empty() {
+            legacy_status.as_slice()
+        } else {
+            EMBEDDED_STATUS
+        };
+        assert_eq!(
+            std::fs::read(fhs_dir.join("bin/status.wasm")).expect("read installed status"),
+            expected
+        );
+
+        let (_, changed) =
+            daemon_cmd::refresh_default_fhs(&ww_dir).expect("refresh unchanged default FHS");
+        assert!(!changed);
     }
 }

--- a/tests/cli_daemon_integration.rs
+++ b/tests/cli_daemon_integration.rs
@@ -1,21 +1,128 @@
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+
 fn ww_bin() -> PathBuf {
     PathBuf::from(std::env::var_os("CARGO_BIN_EXE_ww").expect("CARGO_BIN_EXE_ww missing"))
 }
 
-fn run_ww(home: &Path, args: &[&str]) -> Output {
-    Command::new(ww_bin())
+fn ww_command(home: &Path, args: &[&str]) -> Command {
+    let mut command = Command::new(ww_bin());
+    command
         .args(args)
         .env("HOME", home)
-        .env_remove("WW_IDENTITY")
+        .env_remove("WW_IDENTITY");
+    command
+}
+
+fn run_ww(home: &Path, args: &[&str]) -> Output {
+    ww_command(home, args)
         .output()
         .expect("failed to execute ww")
 }
 
 fn stderr_text(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).to_string()
+}
+
+fn service_arguments(service: &str) -> Vec<String> {
+    if cfg!(target_os = "macos") {
+        let program_arguments = service
+            .split("<key>ProgramArguments</key>")
+            .nth(1)
+            .and_then(|tail| tail.split("</array>").next())
+            .expect("launchd service must contain ProgramArguments");
+        program_arguments
+            .lines()
+            .filter_map(|line| {
+                line.trim()
+                    .strip_prefix("<string>")
+                    .and_then(|value| value.strip_suffix("</string>"))
+                    .map(str::to_owned)
+            })
+            .collect()
+    } else {
+        service
+            .lines()
+            .find_map(|line| line.strip_prefix("ExecStart="))
+            .expect("systemd service must contain ExecStart")
+            .split_whitespace()
+            .map(str::to_owned)
+            .collect()
+    }
+}
+
+fn image_arguments(arguments: &[String]) -> Vec<&str> {
+    let mut images = Vec::new();
+    let mut index = arguments
+        .iter()
+        .position(|argument| argument == "run")
+        .expect("service command must invoke ww run")
+        + 1;
+
+    while index < arguments.len() {
+        match arguments[index].as_str() {
+            "--listen" | "--identity" | "--http-listen" | "--namespace-root" => {
+                index += 2;
+            }
+            argument if argument.starts_with('-') => index += 1,
+            image => {
+                images.push(image);
+                index += 1;
+            }
+        }
+    }
+
+    images
+}
+
+#[cfg(unix)]
+fn embedded_images_hash() -> String {
+    let mut hasher = blake3::Hasher::new();
+    for path in ["std/kernel/bin/main.wasm", "std/status/bin/status.wasm"] {
+        let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+        hasher.update(&std::fs::read(path).unwrap_or_default());
+    }
+    hasher.finalize().to_hex().to_string()
+}
+
+async fn read_http_request(stream: &mut TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut expected_len = None;
+
+    loop {
+        let mut chunk = [0_u8; 4096];
+        let read = stream.read(&mut chunk).await.expect("read request");
+        assert_ne!(read, 0, "request ended before the complete body arrived");
+        request.extend_from_slice(&chunk[..read]);
+
+        if expected_len.is_none() {
+            if let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n") {
+                let headers = String::from_utf8_lossy(&request[..header_end]);
+                let content_len = headers
+                    .lines()
+                    .find_map(|line| {
+                        line.to_ascii_lowercase()
+                            .strip_prefix("content-length:")
+                            .map(str::trim)
+                            .map(str::parse::<usize>)
+                    })
+                    .transpose()
+                    .expect("valid Content-Length")
+                    .expect("multipart request must include Content-Length");
+                expected_len = Some(header_end + 4 + content_len);
+            }
+        }
+
+        if expected_len.is_some_and(|length| request.len() >= length) {
+            return request;
+        }
+    }
 }
 
 #[test]
@@ -66,4 +173,212 @@ fn daemon_install_writes_service_with_listen_args() {
         "{service}"
     );
     assert!(service.contains("--identity"), "{service}");
+}
+
+#[cfg(unix)]
+#[test]
+fn perform_update_restarts_for_service_definition_change_only() {
+    if !cfg!(target_os = "macos") && !cfg!(target_os = "linux") {
+        eprintln!("SKIP: daemon service writer only supports macOS/Linux");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("temp home");
+    let install = run_ww(home.path(), &["daemon", "install"]);
+    assert!(
+        install.status.success(),
+        "daemon install failed: {}",
+        stderr_text(&install)
+    );
+
+    let ww_dir = home.path().join(".ww");
+    std::fs::write(ww_dir.join(".last-std-cid"), embedded_images_hash())
+        .expect("write current image marker");
+
+    let service_path = if cfg!(target_os = "macos") {
+        home.path().join("Library/LaunchAgents/io.wetware.ww.plist")
+    } else {
+        home.path().join(".config/systemd/user/ww.service")
+    };
+    let expected_service = std::fs::read(&service_path).expect("read safe service definition");
+    std::fs::write(
+        &service_path,
+        b"stale service mounted the entire .ww directory\n",
+    )
+    .expect("write stale service definition");
+
+    let tools_dir = home.path().join("test-tools");
+    std::fs::create_dir(&tools_dir).expect("create service-manager stub directory");
+    let service_manager = if cfg!(target_os = "macos") {
+        "launchctl"
+    } else {
+        "systemctl"
+    };
+    let service_manager_path = tools_dir.join(service_manager);
+    std::fs::write(
+        &service_manager_path,
+        "#!/bin/sh\nprintf '%s\\n' \"$*\" >> \"$WW_TEST_SERVICE_COMMAND_LOG\"\n",
+    )
+    .expect("write service-manager stub");
+    let mut permissions = std::fs::metadata(&service_manager_path)
+        .expect("read service-manager stub metadata")
+        .permissions();
+    permissions.set_mode(0o755);
+    std::fs::set_permissions(&service_manager_path, permissions)
+        .expect("make service-manager stub executable");
+
+    let existing_path = std::env::var_os("PATH").unwrap_or_default();
+    let path = std::env::join_paths(
+        std::iter::once(tools_dir).chain(std::env::split_paths(&existing_path)),
+    )
+    .expect("build test PATH");
+    let service_command_log = home.path().join("service-manager.log");
+
+    let stale_update = ww_command(home.path(), &["perform", "update"])
+        .env("PATH", &path)
+        .env("WW_TEST_SERVICE_COMMAND_LOG", &service_command_log)
+        .output()
+        .expect("run update with stale service definition");
+    assert!(
+        stale_update.status.success(),
+        "perform update failed: {}",
+        stderr_text(&stale_update)
+    );
+    assert_eq!(
+        std::fs::read(&service_path).expect("read rewritten service definition"),
+        expected_service,
+        "perform update should replace the stale service definition"
+    );
+
+    let restart_commands = std::fs::read_to_string(&service_command_log)
+        .expect("service restart should invoke the service-manager stub");
+    if cfg!(target_os = "macos") {
+        assert!(restart_commands
+            .lines()
+            .any(|line| line.starts_with("load ")));
+    } else {
+        assert!(restart_commands
+            .lines()
+            .any(|line| line == "--user restart ww"));
+    }
+
+    std::fs::write(&service_command_log, "").expect("clear service-manager log");
+    let unchanged_update = ww_command(home.path(), &["perform", "update"])
+        .env("PATH", &path)
+        .env("WW_TEST_SERVICE_COMMAND_LOG", &service_command_log)
+        .output()
+        .expect("run update with unchanged service definition");
+    assert!(
+        unchanged_update.status.success(),
+        "unchanged perform update failed: {}",
+        stderr_text(&unchanged_update)
+    );
+    assert!(
+        String::from_utf8_lossy(&unchanged_update.stdout)
+            .contains("Daemon restart (nothing changed)"),
+        "unchanged update should skip the daemon restart: {}",
+        String::from_utf8_lossy(&unchanged_update.stdout)
+    );
+    assert!(
+        std::fs::read_to_string(&service_command_log)
+            .expect("read service-manager log")
+            .is_empty(),
+        "unchanged update should not invoke the service manager"
+    );
+}
+
+#[tokio::test]
+async fn default_daemon_import_excludes_private_host_state() {
+    if !cfg!(target_os = "macos") && !cfg!(target_os = "linux") {
+        eprintln!("SKIP: daemon service writer only supports macOS/Linux");
+        return;
+    }
+
+    let home = tempfile::tempdir().expect("temp home");
+    let ww_dir = home.path().join(".ww");
+    let fhs_dir = ww_dir.join("fhs");
+    std::fs::create_dir_all(fhs_dir.join("svc")).expect("publishable FHS tree");
+    std::fs::write(ww_dir.join("identity"), b"PRIVATE_HOST_IDENTITY_SENTINEL")
+        .expect("identity fixture");
+    std::fs::write(
+        ww_dir.join("durable.ipns-record"),
+        b"PRIVATE_MUTABLE_STATE_SENTINEL",
+    )
+    .expect("private state fixture");
+    std::fs::write(
+        fhs_dir.join("svc/deployable.txt"),
+        b"INTENDED_DEPLOYABLE_CONTENT",
+    )
+    .expect("deployable fixture");
+
+    let output = run_ww(home.path(), &["daemon", "install"]);
+    assert!(
+        output.status.success(),
+        "daemon install failed: {}",
+        stderr_text(&output)
+    );
+
+    let service_path = if cfg!(target_os = "macos") {
+        home.path().join("Library/LaunchAgents/io.wetware.ww.plist")
+    } else {
+        home.path().join(".config/systemd/user/ww.service")
+    };
+    let service = std::fs::read_to_string(&service_path)
+        .unwrap_or_else(|error| panic!("failed reading {}: {error}", service_path.display()));
+    let arguments = service_arguments(&service);
+    let images = image_arguments(&arguments);
+    assert_eq!(images, [fhs_dir.to_str().expect("UTF-8 test path")]);
+    assert!(
+        arguments.windows(2).any(|pair| {
+            pair[0] == "--namespace-root" && pair[1] == ww_dir.to_str().expect("UTF-8 test path")
+        }),
+        "service must read namespace state without mounting it: {arguments:?}"
+    );
+
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fake Kubo");
+    let address = listener.local_addr().expect("fake Kubo address");
+    let server = tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept add request");
+        let request = read_http_request(&mut stream).await;
+        let body = b"{\"Name\":\"\",\"Hash\":\"test-root\",\"Size\":\"0\"}\n";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response headers");
+        stream.write_all(body).await.expect("write response body");
+        request
+    });
+
+    let client = ww::ipfs::HttpClient::new(format!("http://{address}"));
+    let root = client
+        .add_dir(Path::new(images[0]))
+        .await
+        .expect("import daemon FHS root");
+    assert_eq!(root, "test-root");
+    let request = server.await.expect("fake Kubo task");
+    let request = String::from_utf8_lossy(&request);
+    assert!(
+        request.contains("filename=\"svc/deployable.txt\"")
+            && request.contains("INTENDED_DEPLOYABLE_CONTENT"),
+        "intended deployable file missing from import request: {request}"
+    );
+    assert!(!request.contains("filename=\"identity\""), "{request}");
+    assert!(
+        !request.contains("PRIVATE_HOST_IDENTITY_SENTINEL"),
+        "{request}"
+    );
+    assert!(
+        !request.contains("filename=\"durable.ipns-record\""),
+        "{request}"
+    );
+    assert!(
+        !request.contains("PRIVATE_MUTABLE_STATE_SENTINEL"),
+        "{request}"
+    );
 }


### PR DESCRIPTION
## Security issue

Installed daemons previously mounted all of `~/.ww` as their default image. Local image directories are recursively imported into Kubo. The default could therefore include `~/.ww/identity` and adjacent private host state in the IPFS DAG.

## Fix

This change establishes a positive publication boundary:

```text
~/.ww/        private host state
~/.ww/fhs/    publishable deployment filesystem
```

Default daemon installations now use `~/.ww/fhs` as the deployment image. The installer materializes the required `status.wasm` under that directory.

Namespace configuration under `~/.ww/etc/ns` is read separately through the host-only `--namespace-root` path. Kubo does not recursively import the namespace root as an image.

## Migration

`ww daemon perform update` rewrites existing installed service definitions to use the safe `~/.ww/fhs` boundary.

The updater restarts the daemon when any of these inputs change:

- image content;
- default FHS content; or
- the rendered service definition.

Service-definition comparison uses the rendered bytes. The installer still rewrites the service definition on each update. This closes the residual case where the updater could write a safe service file while an old vulnerable daemon process remained running.

## Compatibility

- Explicit `ww daemon install --images ...` paths remain explicit images.
- Direct `ww run` behavior remains unchanged.
- Existing private-state locations remain unchanged.
- The update does not rotate identities automatically.
- The update does not delete or unpin historical Kubo blocks automatically.

## Operator remediation

Operators must treat identities used by installed daemons since the vulnerable whole-`~/.ww` behavior was introduced as potentially exposed.

Entry into the DAG does not prove that an attacker retrieved the private key. The key might have been retrievable if a Kubo node provided the corresponding content and its CID became known.

Operators should consider these actions:

1. Deploy this fix.
2. Rotate `~/.ww/identity`.
3. Update PeerID-based trust and authorization mappings.
4. Audit old Kubo pins and retained blocks before explicitly removing them.

Identity rotation changes the node PeerID.

## Deferred work

This PR does not include:

- Phase 3-IPNS;
- IPNS watermark or publisher state;
- routing or `Routing.publish` redesign;
- Cap'n Proto changes;
- WIT changes;
- automatic identity rotation; or
- destructive Kubo pin cleanup.

## Validation

- [x] `cargo fmt --all -- --check`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --test cli_daemon_integration -- --nocapture` — 3 passed, 0 failed
- [x] `cargo test --workspace --no-fail-fast`
- [x] `git diff --check`
- [x] Independent security review: `CLEAR`
- [x] Scope audit: exactly the five approved files; no Phase 3-IPNS or adjacent cleanup
