### PR TITLE
Canonicalize CIDs before CidTree host-path and Kubo use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -332,6 +332,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - **`wetware-membrane`: production membrane recursion (identity, flush, reentry, collapse, bench).** The membrane now preserves capability identity across round-trips and folds stacked attenuations. A data-segment sentinel `get_brand` plus a `get_ptr`-keyed registry lets it recognise its own membranes without `Any` (and without colliding with capnp-rpc connection brands, so caps can't tunnel through the filter). A call parameter that is one of our own membranes is unwrapped to the bare backing cap before reaching the backend, restoring the identity the backend exported (foreign params pass through). Results-copy failures mid-answer now surface as the call's error via an explicit flush outcome instead of a silent empty result. Attenuating an already-membraned cap collapses to a single layer when both policies are static allowlists (intersection of key sets via the new `Policy::allowlist_keys`); stateful policies stack so their per-call state survives. Adds `benches/membrane.rs`: per-call overhead is sub-microsecond and constant per hop (ping +~357 ns, cap-returning child +~437 ns), so upstream capnp cap-table work stays deferred.
 
 ### Fixed
+- **CidTree rejects untrusted CID spellings before host-path or Kubo use.**
+  Directory walking now parses and canonicalizes intermediate directory CIDs
+  before cache lookup, persisted-listing access, or Kubo lookup. File
+  materialization also uses the parsed CID's canonical text for its cache path.
 - **Replacement pid0 generations cannot become ready before successful
   initialization.** Readiness requires an explicit commit by the trusted PID0
   kernel through its private Component Model host

--- a/crates/cell/src/fs_intercept.rs
+++ b/crates/cell/src/fs_intercept.rs
@@ -257,17 +257,18 @@ pub(crate) async fn materialize_cid_tree_descriptor(
         ResolvedNode::CidFile { cid, .. } => {
             let cache = cache.ok_or(MaterializeError::Io)?;
             let parsed = cid.parse::<cid::Cid>().map_err(|_| MaterializeError::Io)?;
+            let canonical_cid = parsed.to_string();
             cache.ensure(&parsed).await.map_err(|error| {
-                tracing::warn!(%cid, %error, "CidTree cache ensure failed");
+                tracing::warn!(%canonical_cid, %error, "CidTree cache ensure failed");
                 MaterializeError::Io
             })?;
-            let staging_path = cache.staging_dir().join(&cid);
+            let staging_path = cache.staging_dir().join(&canonical_cid);
             if !staging_path.exists() {
                 cache
                     .fetch_to_path(&parsed, &staging_path)
                     .await
                     .map_err(|error| {
-                        tracing::warn!(%cid, %error, "CidTree stream fetch failed");
+                        tracing::warn!(%canonical_cid, %error, "CidTree stream fetch failed");
                         MaterializeError::Io
                     })?;
             }
@@ -1284,6 +1285,48 @@ mod tests {
         assert!(matches!(result, Err(MaterializeError::Invalid)));
         assert!(!root.path().join("escaped").exists());
         assert_eq!(std::fs::read_dir(staging).unwrap().count(), 1);
+    }
+
+    #[tokio::test]
+    async fn cid_tree_file_materialization_uses_canonical_cid_path() {
+        let content = b"confined file content";
+        let (cid, pinner) = test_cid_and_pinner(content);
+        let escape_root = tempfile::TempDir::new().unwrap();
+        let escaped_parent = escape_root.path().join("escaped");
+        let escaped_path = escaped_parent.join("ipfs").join(cid.to_string());
+        let hostile_cid = format!("{}/ipfs/{cid}", escaped_parent.display());
+
+        let tree_staging = tempfile::TempDir::new().unwrap();
+        let entries = vec![crate::vfs::DirEntry {
+            name: "hostile-file".to_string(),
+            cid: hostile_cid,
+            entry_type: crate::vfs::EntryType::File,
+            size: content.len() as u64,
+        }];
+        std::fs::write(
+            tree_staging.path().join(format!("{cid}.dirlist.json")),
+            serde_json::to_vec(&entries).unwrap(),
+        )
+        .unwrap();
+        let tree = CidTree::new(
+            cid.to_string(),
+            ipfs::HttpClient::new("http://127.0.0.1:1".to_string()),
+            tree_staging.path().to_path_buf(),
+        );
+        let cache = cache::CacheMode::Isolated(cache::IsolatedPinset::new(pinner).unwrap());
+        let canonical_path = cache.staging_dir().join(cid.to_string());
+
+        let descriptor =
+            materialize_cid_tree_descriptor(Some(&cache), &tree, "hostile-file", false)
+                .await
+                .unwrap();
+        drop(descriptor);
+
+        assert_eq!(std::fs::read(&canonical_path).unwrap(), content);
+        assert!(
+            !escaped_path.exists(),
+            "a parseable CID string must not escape the cache staging directory"
+        );
     }
 
     // ── Mock pinner for integration tests ──────────────────────────

--- a/crates/cell/src/vfs.rs
+++ b/crates/cell/src/vfs.rs
@@ -137,24 +137,31 @@ impl CidTree {
     /// 2. Staging disk (hit → populate LRU, return)
     /// 3. IPFS daemon `ls()` (populate both caches, return)
     pub async fn ls_dir(&self, cid: &str) -> Result<Vec<DirEntry>> {
+        let canonical = cid
+            .parse::<cid::Cid>()
+            .with_context(|| format!("invalid directory CID: {cid}"))?
+            .to_string();
+
         // Tier 1: in-memory LRU
         if let Some(entries) = self
             .dir_cache
             .lock()
             .ok()
-            .and_then(|mut c| c.get(cid).cloned())
+            .and_then(|mut c| c.get(&canonical).cloned())
         {
             return Ok(entries);
         }
 
         // Tier 2: staging disk
-        let disk_path = self.staging_dir.join(format!("{cid}{DIRLIST_SUFFIX}"));
+        let disk_path = self
+            .staging_dir
+            .join(format!("{canonical}{DIRLIST_SUFFIX}"));
         if disk_path.exists() {
             if let Ok(data) = std::fs::read_to_string(&disk_path) {
                 if let Ok(entries) = serde_json::from_str::<Vec<DirEntry>>(&data) {
                     // Populate LRU from disk
                     if let Ok(mut cache) = self.dir_cache.lock() {
-                        cache.put(cid.to_string(), entries.clone());
+                        cache.put(canonical.clone(), entries.clone());
                     }
                     return Ok(entries);
                 }
@@ -162,12 +169,12 @@ impl CidTree {
         }
 
         // Tier 3: IPFS daemon
-        let ipfs_path = format!("/ipfs/{cid}");
+        let ipfs_path = format!("/ipfs/{canonical}");
         let raw_entries = self
             .ipfs
             .ls(&ipfs_path)
             .await
-            .with_context(|| format!("ls failed for CID {cid}"))?;
+            .with_context(|| format!("ls failed for CID {canonical}"))?;
 
         let entries: Vec<DirEntry> = raw_entries
             .into_iter()
@@ -193,7 +200,7 @@ impl CidTree {
 
         // Populate LRU
         if let Ok(mut cache) = self.dir_cache.lock() {
-            cache.put(cid.to_string(), entries.clone());
+            cache.put(canonical, entries.clone());
         }
 
         Ok(entries)
@@ -363,6 +370,9 @@ impl std::fmt::Debug for CidTree {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    use tokio::net::TcpListener;
 
     #[test]
     fn test_path_traversal_rejected() {
@@ -394,5 +404,114 @@ mod tests {
         assert_eq!(deserialized.len(), 2);
         assert_eq!(deserialized[0].name, "bin");
         assert_eq!(deserialized[1].entry_type, EntryType::File);
+    }
+
+    #[tokio::test]
+    async fn resolve_path_rejects_invalid_intermediate_directory_cid_before_io() {
+        let root_cid = "QmYwAPJzv5CZsnN625s3Xf2nemtYgPpHdWEz79ojWnPbdG";
+        let root = tempfile::TempDir::new().unwrap();
+        let staging = root.path().join("staging");
+        std::fs::create_dir(&staging).unwrap();
+        std::fs::create_dir(staging.join("segment")).unwrap();
+        let entries = vec![DirEntry {
+            name: "hostile".to_string(),
+            cid: "segment/../../escaped".to_string(),
+            entry_type: EntryType::Dir,
+            size: 0,
+        }];
+        std::fs::write(
+            staging.join(format!("{root_cid}{DIRLIST_SUFFIX}")),
+            serde_json::to_vec(&entries).unwrap(),
+        )
+        .unwrap();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let lookups = Arc::new(AtomicUsize::new(0));
+        let server_lookups = Arc::clone(&lookups);
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            server_lookups.fetch_add(1, Ordering::SeqCst);
+            let mut request = [0u8; 4096];
+            let bytes_read = stream.read(&mut request).await.unwrap();
+            assert!(bytes_read > 0, "Kubo request must not be empty");
+            stream
+                .write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Length: 26\r\nConnection: close\r\n\r\n{\"Objects\":[{\"Links\":[]}]}",
+                )
+                .await
+                .unwrap();
+        });
+        let tree = CidTree::new(
+            root_cid.to_string(),
+            ipfs::HttpClient::new(format!("http://{address}")),
+            staging.clone(),
+        );
+
+        let error = tree
+            .resolve_path("hostile/child")
+            .await
+            .expect_err("an invalid intermediate directory CID must fail resolution");
+
+        assert!(
+            error.to_string().contains("invalid directory CID"),
+            "unexpected resolution error: {error:#}"
+        );
+        assert_eq!(
+            lookups.load(Ordering::SeqCst),
+            0,
+            "an invalid CID must not reach Kubo"
+        );
+        assert!(
+            !root
+                .path()
+                .join(format!("escaped{DIRLIST_SUFFIX}"))
+                .exists(),
+            "an invalid CID must not create a cache file outside staging"
+        );
+        assert_eq!(
+            std::fs::read_dir(root.path()).unwrap().count(),
+            1,
+            "resolution must not create any path outside staging"
+        );
+
+        server.abort();
+        let _ = server.await;
+    }
+
+    #[tokio::test]
+    async fn valid_cid_representations_share_canonical_directory_cache_identity() {
+        let canonical = "bafkreibm6jg3ux5quy7flfgn5gmxk5ubm6yur3apcu3to3d6tmjzptm2ye";
+        let parsed = canonical.parse::<cid::Cid>().unwrap();
+        let alternate = parsed
+            .to_string_of_base(cid::multibase::Base::Base58Btc)
+            .unwrap();
+        assert_ne!(alternate, canonical);
+
+        let staging = tempfile::TempDir::new().unwrap();
+        let entries = vec![DirEntry {
+            name: "child".to_string(),
+            cid: canonical.to_string(),
+            entry_type: EntryType::File,
+            size: 7,
+        }];
+        let disk_path = staging.path().join(format!("{canonical}{DIRLIST_SUFFIX}"));
+        std::fs::write(&disk_path, serde_json::to_vec(&entries).unwrap()).unwrap();
+        let tree = CidTree::new(
+            alternate,
+            ipfs::HttpClient::new("http://127.0.0.1:1".to_string()),
+            staging.path().to_path_buf(),
+        );
+
+        let resolved = tree.resolve_path("child").await.unwrap();
+        assert!(matches!(
+            resolved,
+            ResolvedNode::CidFile { cid, size: 7 } if cid == canonical
+        ));
+
+        std::fs::remove_file(disk_path).unwrap();
+        let cached = tree.ls_dir(canonical).await.unwrap();
+        assert_eq!(cached.len(), 1);
+        assert_eq!(cached[0].name, "child");
     }
 }


### PR DESCRIPTION
## Summary

- validate and canonicalize intermediate directory CIDs in `CidTree::ls_dir`
  before cache, filesystem, or Kubo use;
- canonicalize terminal `CidFile` cache and materialization paths after parsing;
- ensure equivalent valid CID representations share one cache identity;
- add regressions for hostile intermediate-directory metadata and alternate
  valid CID representations.

## Security/correctness

Directory metadata is not trusted as a filesystem-safe string.

A CID is now semantically parsed before it can influence:

- host staging and cache paths;
- CidTree cache keys;
- Kubo `/ipfs/...` requests.

The regressions demonstrate that traversal-shaped metadata is rejected before
host filesystem or Kubo I/O.

## Scope

This is a narrow CidTree and filesystem trust-boundary fix.

It does not:

- change the P3 runtime;
- start PR-3;
- modify directory-relative-open semantics;
- change immutable-file open flags;
- address the separate image and MFS trust boundary.

## Validation

- `make test-p3-fixture`: native P3 artifact validated; 16 WASI 0.3.x imports;
  no WASI 0.2 or socket imports; 6 artifact-backed P3 tests passed, including
  filesystem parity.
- `cargo test -p cell vfs::tests::`: 4 passed.
- `cargo test -p cell fs_intercept::tests::`: 15 passed.
- `cargo test -p cell`: 103 passed; 6 artifact-gated P3 tests were then run by
  the native-P3 fixture lane.
- `cargo fmt --all -- --check`
- `cargo check -p cell --all-targets`
- `cargo clippy -p cell --all-targets -- -D warnings`
- `git diff --check`
